### PR TITLE
Sanitize inputs

### DIFF
--- a/Web Socket/api.php
+++ b/Web Socket/api.php
@@ -11,9 +11,9 @@ function clean($string) {
 //post data
 $credentials = trim(clean($_POST['credentials']));
 $title = trim(clean($_POST['title']));
-$message = trim(clean($_POST['message']));
-$imageURL = trim(clean($_POST['img']));
-$link = trim(clean($_POST['link']));
+$message = trim($_POST['message']);
+$imageURL = trim($_POST['img']);
+$link = trim($_POST['link']);
 
 //other variables
 $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];


### PR DESCRIPTION
In the same way we call:
```php
function clean($string) {
   $string = str_replace(' ', '', $string); // removes all spaces
   return preg_replace('/[^A-Za-z0-9\-]/', '', $string);
}
```

on `$credentials` to prevent sqli, we should do the same for the other user-controlled inputs, as done in this branch (for api.php).

If it is all taken care of later in the code by the following prepared statement:

```php
$stmt = $mysqli->prepare("INSERT INTO notifications (credentials, title, message, image, link, ip) VALUES (
AES_ENCRYPT(?,'$key'),
AES_ENCRYPT(?,'$key'),
AES_ENCRYPT(?,'$key'),
AES_ENCRYPT(?,'$key'),
AES_ENCRYPT(?,'$key'),
AES_ENCRYPT(?,'$key')
)");
```
Then this pull request should be rejected, and calling clean() on any input might be useless.

I am not clear on whether it is. Needs discussion.