### PR TITLE
Say what 2.0.8 changed

### DIFF
--- a/apps/app/fastlane/metadata/de-DE/release_notes.txt
+++ b/apps/app/fastlane/metadata/de-DE/release_notes.txt
@@ -1,3 +1,3 @@
-notifi 2.0 ist eine komplette Neuentwicklung. Die alte Flutter-App ist verschwunden; diese ist nativ in Swift geschrieben, von Grund auf neu gestaltet.
+Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Suche durchsucht die Inbox. Die Zählung über der Liste ist verschwunden.
 
-Schnellerer Start, natives Text-Rendering und ein gemeinsames Layout für alle drei Tabs. Der Bildschirm Schlüssel sagt jetzt, wofür ein Schlüssel steht, und der eingebaute Standardschlüssel führt die Liste an. Zeitstempel bei Nachrichten sind reine Ziffern, die sich kopieren lassen.
+Auf dem iPad nutzt die App die volle Breite des Bildschirms statt einer Spalte in Telefonbreite, und die Liste scrollt unter der Tab-Leiste bis zum unteren Rand. Das Schlüsselsymbol in der Tab-Leiste wird dort nicht mehr abgeschnitten.

--- a/apps/app/fastlane/metadata/de-DE/release_notes.txt
+++ b/apps/app/fastlane/metadata/de-DE/release_notes.txt
@@ -1,3 +1,3 @@
-Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Suche durchsucht die Inbox. Die Zählung über der Liste ist verschwunden.
+Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Zählung über der Liste ist verschwunden.
 
 Auf dem iPad nutzt die App die volle Breite des Bildschirms statt einer Spalte in Telefonbreite, und die Liste scrollt unter der Tab-Leiste bis zum unteren Rand. Das Schlüsselsymbol in der Tab-Leiste wird dort nicht mehr abgeschnitten.

--- a/apps/app/fastlane/metadata/en-GB/release_notes.txt
+++ b/apps/app/fastlane/metadata/en-GB/release_notes.txt
@@ -1,3 +1,3 @@
-The Notifications screen is called the Inbox now, and search asks to search the inbox. The count above the list is gone.
+The Notifications screen is called the Inbox now, and the count above the list is gone.
 
 On iPad the app uses the full width of the screen rather than a phone-width column, and the list scrolls under the tab bar to the bottom edge. The key icon in the tab bar is no longer clipped there.

--- a/apps/app/fastlane/metadata/en-GB/release_notes.txt
+++ b/apps/app/fastlane/metadata/en-GB/release_notes.txt
@@ -1,3 +1,3 @@
-notifi 2.0 is a ground-up rewrite. The old Flutter app is gone; this one is native Swift, redesigned top to bottom.
+The Notifications screen is called the Inbox now, and search asks to search the inbox. The count above the list is gone.
 
-Faster launch, native text rendering, and one shared layout across the three tabs. The Keys screen now says what a key is, and the built-in default key leads the list. Notification timestamps are plain digits you can copy.
+On iPad the app uses the full width of the screen rather than a phone-width column, and the list scrolls under the tab bar to the bottom edge. The key icon in the tab bar is no longer clipped there.

--- a/apps/app/fastlane/metadata/es-ES/release_notes.txt
+++ b/apps/app/fastlane/metadata/es-ES/release_notes.txt
@@ -1,3 +1,3 @@
-La pantalla Notificaciones ahora se llama Inbox, y la búsqueda busca en la Inbox. El recuento sobre la lista ha desaparecido.
+La pantalla Notificaciones ahora se llama Inbox y el recuento sobre la lista ha desaparecido.
 
 En iPad la app usa todo el ancho de la pantalla en lugar de una columna con ancho de teléfono, y la lista se desplaza bajo la barra de pestañas hasta el borde inferior. El icono de la llave en la barra de pestañas ya no aparece recortado.

--- a/apps/app/fastlane/metadata/es-ES/release_notes.txt
+++ b/apps/app/fastlane/metadata/es-ES/release_notes.txt
@@ -1,3 +1,3 @@
-notifi 2.0 es una reescritura desde cero. La antigua app en Flutter ha desaparecido; esta es Swift nativo, rediseñada de arriba abajo.
+La pantalla Notificaciones ahora se llama Inbox, y la búsqueda busca en la Inbox. El recuento sobre la lista ha desaparecido.
 
-Inicio más rápido, renderizado de texto nativo y un mismo diseño compartido entre las tres pestañas. La pantalla de Claves ahora explica qué es una clave, y la clave predeterminada encabeza la lista. Las marcas de tiempo de los mensajes son dígitos simples que puedes copiar.
+En iPad la app usa todo el ancho de la pantalla en lugar de una columna con ancho de teléfono, y la lista se desplaza bajo la barra de pestañas hasta el borde inferior. El icono de la llave en la barra de pestañas ya no aparece recortado.

--- a/apps/app/fastlane/metadata/fr-FR/release_notes.txt
+++ b/apps/app/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,3 +1,3 @@
-L'écran Notifications s'appelle désormais Inbox, et la recherche porte sur l'Inbox. Le compteur au-dessus de la liste a disparu.
+L'écran Notifications s'appelle désormais Inbox, et le compteur au-dessus de la liste a disparu.
 
 Sur iPad, l'app occupe toute la largeur de l'écran au lieu d'une colonne à la largeur d'un téléphone, et la liste défile sous la barre d'onglets jusqu'au bord inférieur. L'icône de clé dans la barre d'onglets n'est plus rognée.

--- a/apps/app/fastlane/metadata/fr-FR/release_notes.txt
+++ b/apps/app/fastlane/metadata/fr-FR/release_notes.txt
@@ -1,3 +1,3 @@
-notifi 2.0 est une réécriture complète. L'ancienne application Flutter a disparu ; celle-ci est en Swift natif, repensée de fond en comble.
+L'écran Notifications s'appelle désormais Inbox, et la recherche porte sur l'Inbox. Le compteur au-dessus de la liste a disparu.
 
-Lancement plus rapide, rendu de texte natif, et une seule mise en page partagée entre les trois onglets. L'écran Clés indique désormais ce qu'est une clé, et la clé par défaut intégrée mène la liste. Les horodatages des messages sont de simples chiffres que vous pouvez copier.
+Sur iPad, l'app occupe toute la largeur de l'écran au lieu d'une colonne à la largeur d'un téléphone, et la liste défile sous la barre d'onglets jusqu'au bord inférieur. L'icône de clé dans la barre d'onglets n'est plus rognée.

--- a/apps/app/fastlane/metadata/it/release_notes.txt
+++ b/apps/app/fastlane/metadata/it/release_notes.txt
@@ -1,3 +1,3 @@
-notifi 2.0 è una riscrittura completa. La vecchia app Flutter è sparita; questa è nativa Swift, ridisegnata da cima a fondo.
+La schermata Notifiche ora si chiama Inbox e la ricerca cerca nella Inbox. Il conteggio sopra l'elenco è sparito.
 
-Avvio più veloce, rendering nativo del testo, e un unico layout condiviso tra le tre schede. La schermata Chiavi ora spiega cos'è una chiave, e la chiave predefinita integrata guida l'elenco. I timestamp dei messaggi sono cifre semplici che puoi copiare.
+Su iPad l'app usa tutta la larghezza dello schermo invece di una colonna larga quanto un telefono, e l'elenco scorre sotto la barra delle schede fino al bordo inferiore. L'icona della chiave nella barra delle schede non è più tagliata.

--- a/apps/app/fastlane/metadata/it/release_notes.txt
+++ b/apps/app/fastlane/metadata/it/release_notes.txt
@@ -1,3 +1,3 @@
-La schermata Notifiche ora si chiama Inbox e la ricerca cerca nella Inbox. Il conteggio sopra l'elenco è sparito.
+La schermata Notifiche ora si chiama Inbox e il conteggio sopra l'elenco è sparito.
 
 Su iPad l'app usa tutta la larghezza dello schermo invece di una colonna larga quanto un telefono, e l'elenco scorre sotto la barra delle schede fino al bordo inferiore. L'icona della chiave nella barra delle schede non è più tagliata.

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -69,7 +69,7 @@ export const copy = {
       'Mark a key as urgent and its notifications break through Focus and land on the lock ' +
       'screen.\n',
     releaseNotes:
-      'The Notifications screen is called the Inbox now, and search asks to search the inbox. The count above the list is gone.\n\n' +
+      'The Notifications screen is called the Inbox now, and the count above the list is gone.\n\n' +
       'On iPad the app uses the full width of the screen rather than a phone-width column, and the list scrolls under the tab bar to the bottom edge. The key icon in the tab bar is no longer clipped there.\n',
 
     shotInboxTitle: 'One request.\nStraight to your pocket.',

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -69,11 +69,8 @@ export const copy = {
       'Mark a key as urgent and its notifications break through Focus and land on the lock ' +
       'screen.\n',
     releaseNotes:
-      'notifi 2.0 is a ground-up rewrite. The old Flutter app is gone; this one is native ' +
-      'Swift, redesigned top to bottom.\n\n' +
-      'Faster launch, native text rendering, and one shared layout across the three tabs. ' +
-      'The Keys screen now says what a key is, and the built-in default key leads the list. ' +
-      'Notification timestamps are plain digits you can copy.\n',
+      'The Notifications screen is called the Inbox now, and search asks to search the inbox. The count above the list is gone.\n\n' +
+      'On iPad the app uses the full width of the screen rather than a phone-width column, and the list scrolls under the tab bar to the bottom edge. The key icon in the tab bar is no longer clipped there.\n',
 
     shotInboxTitle: 'One request.\nStraight to your pocket.',
     shotInboxBody:

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -66,12 +66,8 @@ export const de: Translation = {
     'Markiere einen Schlüssel als dringend, und seine Benachrichtigungen durchbrechen ' +
     'den Fokus und landen auf dem Sperrbildschirm.\n',
   'store.releaseNotes':
-    'notifi 2.0 ist eine komplette Neuentwicklung. Die alte Flutter-App ist verschwunden; ' +
-    'diese ist nativ in Swift geschrieben, von Grund auf neu gestaltet.\n\n' +
-    'Schnellerer Start, natives Text-Rendering und ein gemeinsames Layout für alle drei ' +
-    'Tabs. Der Bildschirm Schlüssel sagt jetzt, wofür ein Schlüssel steht, und der ' +
-    'eingebaute Standardschlüssel führt die Liste an. Zeitstempel bei Nachrichten sind ' +
-    'reine Ziffern, die sich kopieren lassen.\n',
+    'Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Suche durchsucht die Inbox. Die Zählung über der Liste ist verschwunden.\n\n' +
+    'Auf dem iPad nutzt die App die volle Breite des Bildschirms statt einer Spalte in Telefonbreite, und die Liste scrollt unter der Tab-Leiste bis zum unteren Rand. Das Schlüsselsymbol in der Tab-Leiste wird dort nicht mehr abgeschnitten.\n',
 
   'store.shotInboxTitle': 'Eine Anfrage.\nDirekt in deine Tasche.',
   'store.shotInboxBody':

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -66,7 +66,7 @@ export const de: Translation = {
     'Markiere einen Schlüssel als dringend, und seine Benachrichtigungen durchbrechen ' +
     'den Fokus und landen auf dem Sperrbildschirm.\n',
   'store.releaseNotes':
-    'Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Suche durchsucht die Inbox. Die Zählung über der Liste ist verschwunden.\n\n' +
+    'Der Bildschirm Benachrichtigungen heißt jetzt Inbox, und die Zählung über der Liste ist verschwunden.\n\n' +
     'Auf dem iPad nutzt die App die volle Breite des Bildschirms statt einer Spalte in Telefonbreite, und die Liste scrollt unter der Tab-Leiste bis zum unteren Rand. Das Schlüsselsymbol in der Tab-Leiste wird dort nicht mehr abgeschnitten.\n',
 
   'store.shotInboxTitle': 'Eine Anfrage.\nDirekt in deine Tasche.',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -374,7 +374,7 @@ export const es: Translation = {
     'Marca una clave como urgente y sus notificaciones atraviesan el modo Enfoque y aparecen en la ' +
     'pantalla de bloqueo.\n',
   'store.releaseNotes':
-    'La pantalla Notificaciones ahora se llama Inbox, y la búsqueda busca en la Inbox. El recuento sobre la lista ha desaparecido.\n\n' +
+    'La pantalla Notificaciones ahora se llama Inbox y el recuento sobre la lista ha desaparecido.\n\n' +
     'En iPad la app usa todo el ancho de la pantalla en lugar de una columna con ancho de teléfono, y la lista se desplaza bajo la barra de pestañas hasta el borde inferior. El icono de la llave en la barra de pestañas ya no aparece recortado.\n',
   'store.shotInboxTitle': 'Una solicitud.\nDirecto a tu bolsillo.',
   'store.shotInboxBody':

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -374,12 +374,8 @@ export const es: Translation = {
     'Marca una clave como urgente y sus notificaciones atraviesan el modo Enfoque y aparecen en la ' +
     'pantalla de bloqueo.\n',
   'store.releaseNotes':
-    'notifi 2.0 es una reescritura desde cero. La antigua app en Flutter ha desaparecido; esta es ' +
-    'Swift nativo, rediseñada de arriba abajo.\n\n' +
-    'Inicio más rápido, renderizado de texto nativo y un mismo diseño compartido entre las tres ' +
-    'pestañas. La pantalla de Claves ahora explica qué es una clave, y la clave predeterminada ' +
-    'encabeza la lista. Las marcas de tiempo de los mensajes son dígitos simples que puedes copiar.\n',
-
+    'La pantalla Notificaciones ahora se llama Inbox, y la búsqueda busca en la Inbox. El recuento sobre la lista ha desaparecido.\n\n' +
+    'En iPad la app usa todo el ancho de la pantalla en lugar de una columna con ancho de teléfono, y la lista se desplaza bajo la barra de pestañas hasta el borde inferior. El icono de la llave en la barra de pestañas ya no aparece recortado.\n',
   'store.shotInboxTitle': 'Una solicitud.\nDirecto a tu bolsillo.',
   'store.shotInboxBody':
     'Notificaciones push para tus scripts y servidores. Una solicitud HTTP a notifi.it y llega un ' +

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -367,13 +367,8 @@ export const fr: Translation = {
     'Marquez une clé comme urgente et ses notifications franchissent Focus et arrivent sur ' +
     "l'écran verrouillé.\n",
   'store.releaseNotes':
-    "notifi 2.0 est une réécriture complète. L'ancienne application Flutter a disparu ; " +
-    "celle-ci est en Swift natif, repensée de fond en comble.\n\n" +
-    'Lancement plus rapide, rendu de texte natif, et une seule mise en page partagée entre ' +
-    'les trois onglets. L\'écran Clés indique désormais ce qu\'est une clé, et la clé par ' +
-    "défaut intégrée mène la liste. Les horodatages des messages sont de simples chiffres " +
-    'que vous pouvez copier.\n',
-
+    "L'écran Notifications s'appelle désormais Inbox, et la recherche porte sur l'Inbox. Le compteur au-dessus de la liste a disparu.\n\n" +
+    "Sur iPad, l'app occupe toute la largeur de l'écran au lieu d'une colonne à la largeur d'un téléphone, et la liste défile sous la barre d'onglets jusqu'au bord inférieur. L'icône de clé dans la barre d'onglets n'est plus rognée.\n",
   'store.shotInboxTitle': 'Une requête.\nDroit dans votre poche.',
   'store.shotInboxBody':
     'Notifications push pour vos scripts et serveurs. Une requête HTTP vers notifi.it et ' +

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -367,7 +367,7 @@ export const fr: Translation = {
     'Marquez une clé comme urgente et ses notifications franchissent Focus et arrivent sur ' +
     "l'écran verrouillé.\n",
   'store.releaseNotes':
-    "L'écran Notifications s'appelle désormais Inbox, et la recherche porte sur l'Inbox. Le compteur au-dessus de la liste a disparu.\n\n" +
+    "L'écran Notifications s'appelle désormais Inbox, et le compteur au-dessus de la liste a disparu.\n\n" +
     "Sur iPad, l'app occupe toute la largeur de l'écran au lieu d'une colonne à la largeur d'un téléphone, et la liste défile sous la barre d'onglets jusqu'au bord inférieur. L'icône de clé dans la barre d'onglets n'est plus rognée.\n",
   'store.shotInboxTitle': 'Une requête.\nDroit dans votre poche.',
   'store.shotInboxBody':

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -375,11 +375,8 @@ export const it: Translation = {
     'Contrassegna una chiave come urgente e le sue notifiche superano Focus e arrivano sulla ' +
     'schermata di blocco.\n',
   'store.releaseNotes':
-    'notifi 2.0 è una riscrittura completa. La vecchia app Flutter è sparita; questa è nativa ' +
-    'Swift, ridisegnata da cima a fondo.\n\n' +
-    'Avvio più veloce, rendering nativo del testo, e un unico layout condiviso tra le tre schede. ' +
-    'La schermata Chiavi ora spiega cos\'è una chiave, e la chiave predefinita integrata guida ' +
-    'l\'elenco. I timestamp dei messaggi sono cifre semplici che puoi copiare.\n',
+    "La schermata Notifiche ora si chiama Inbox e la ricerca cerca nella Inbox. Il conteggio sopra l'elenco è sparito.\n\n" +
+    "Su iPad l'app usa tutta la larghezza dello schermo invece di una colonna larga quanto un telefono, e l'elenco scorre sotto la barra delle schede fino al bordo inferiore. L'icona della chiave nella barra delle schede non è più tagliata.\n",
   'store.shotInboxTitle': 'Una richiesta.\nDritta in tasca.',
   'store.shotInboxBody':
     'Notifiche push per i tuoi script e server. Una richiesta HTTP a notifi.it e arriva un ' +

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -375,7 +375,7 @@ export const it: Translation = {
     'Contrassegna una chiave come urgente e le sue notifiche superano Focus e arrivano sulla ' +
     'schermata di blocco.\n',
   'store.releaseNotes':
-    "La schermata Notifiche ora si chiama Inbox e la ricerca cerca nella Inbox. Il conteggio sopra l'elenco è sparito.\n\n" +
+    "La schermata Notifiche ora si chiama Inbox e il conteggio sopra l'elenco è sparito.\n\n" +
     "Su iPad l'app usa tutta la larghezza dello schermo invece di una colonna larga quanto un telefono, e l'elenco scorre sotto la barra delle schede fino al bordo inferiore. L'icona della chiave nella barra delle schede non è più tagliata.\n",
   'store.shotInboxTitle': 'Una richiesta.\nDritta in tasca.',
   'store.shotInboxBody':


### PR DESCRIPTION
The release notes still announced the 2.0 rewrite, so shipping them again would tell everyone about a release they already have. The four translations are mechanical, the same sentences with the nouns each language already uses, and want a native read before they go out.