### PR TITLE
Report the OS version a device is running at registration

### DIFF
--- a/apps/api/migrations/0002_device_os_version.sql
+++ b/apps/api/migrations/0002_device_os_version.sql
@@ -1,0 +1,6 @@
+-- Devices report the OS version they are running at registration, alongside
+-- platform and app_version. Nullable: rows registered before this column
+-- existed have no value until that device registers again.
+
+-- AlterTable
+ALTER TABLE "devices" ADD COLUMN "os_version" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -26,6 +26,7 @@ model devices {
   apns_token_hmac       String  @unique
   platform              String
   app_version           String
+  os_version            String?
   created_at            Int
   last_seen_at          Int
   acked_id              Int     @default(0)

--- a/apps/api/src/routes/devices.ts
+++ b/apps/api/src/routes/devices.ts
@@ -47,6 +47,7 @@ devices.post('/devices', async (c) => {
   const apnsEnc = await encryptField(c.env, parsed.apns_token);
   const platformEnc = await encryptPadded(c.env, parsed.platform);
   const versionEnc = await encryptPadded(c.env, parsed.app_version);
+  const osVersionEnc = await encryptPadded(c.env, parsed.os_version);
 
   const retireOthers = c.env.DB.prepare(
     `UPDATE devices SET apns_token = '', apns_token_hmac = 'retired:' || id
@@ -55,14 +56,15 @@ devices.post('/devices', async (c) => {
 
   const upsert = c.env.DB.prepare(
     `INSERT INTO devices
-       (public_key, encryption_public_key, apns_token, apns_token_hmac, platform, app_version, created_at, last_seen_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       (public_key, encryption_public_key, apns_token, apns_token_hmac, platform, app_version, os_version, created_at, last_seen_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(public_key) DO UPDATE SET
        encryption_public_key = excluded.encryption_public_key,
        apns_token            = excluded.apns_token,
        apns_token_hmac       = excluded.apns_token_hmac,
        platform              = excluded.platform,
        app_version           = excluded.app_version,
+       os_version            = excluded.os_version,
        last_seen_at          = excluded.last_seen_at
      RETURNING id, strict_send`,
   ).bind(
@@ -72,6 +74,7 @@ devices.post('/devices', async (c) => {
     tokenHmac,
     platformEnc,
     versionEnc,
+    osVersionEnc,
     nowS,
     nowS,
   );

--- a/apps/app/Shared/API/ContractModels.swift
+++ b/apps/app/Shared/API/ContractModels.swift
@@ -6,6 +6,7 @@ struct RegisterDeviceBody: Codable, Sendable {
     let apnsToken: String
     let platform: String
     let appVersion: String
+    let osVersion: String
 
     enum CodingKeys: String, CodingKey {
         case publicKey = "public_key"
@@ -13,6 +14,7 @@ struct RegisterDeviceBody: Codable, Sendable {
         case apnsToken = "apns_token"
         case platform
         case appVersion = "app_version"
+        case osVersion = "os_version"
     }
 }
 

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -336,7 +336,8 @@ final class AppModel {
             encryptionPublicKey: identity.encryptionPublicKeyX963.base64EncodedString(),
             apnsToken: apnsToken,
             platform: Self.platformName,
-            appVersion: Self.appVersion
+            appVersion: Self.appVersion,
+            osVersion: Self.osVersion
         )
         do {
             let response = try await api.registerDevice(body)
@@ -526,6 +527,13 @@ final class AppModel {
 
     static var appVersion: String {
         (Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String) ?? "0"
+    }
+
+    static var osVersion: String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return v.patchVersion == 0
+            ? "\(v.majorVersion).\(v.minorVersion)"
+            : "\(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
     }
 
 }

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -70,6 +70,7 @@ export const registerDeviceBody = z
     apns_token: z.string().min(1),
     platform: z.string().min(1).max(16),
     app_version: z.string().min(1).max(16),
+    os_version: z.string().min(1).max(16),
   })
   .strict();
 export type RegisterDeviceBody = z.infer<typeof registerDeviceBody>;


### PR DESCRIPTION
Registration carried `platform` and `app_version` but not which OS release the device is on, so the app now sends `os_version` — `26.4`, or `26.4.1` when there is a patch component — stored beside the other two and field-encrypted the same way. The column is nullable, so the migration is an in-place `ADD COLUMN` rather than a table rebuild, and rows written before it stay empty until that device registers again. Because the field is required in the contract, a shipped build that predates it gets a 400 on register until it updates, which leaves pushes working off the stored APNs token but stops token refresh on stale builds. No UI, so no screenshots; `make typecheck`, `make lint`, `make check-migrations`, `make migrate` and both `xcodebuild` schemes pass, with no live registration round-trip against the Worker.