### PR TITLE
Ask for notification permission at launch and create the default key sooner

### DIFF
--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -241,11 +241,17 @@ final class AppModel {
         if wantsLiveUpdates { startLiveUpdates() }
 
         Task {
-            await enqueueRegistration(token: token).value
             await refreshPermission()
-            await sync?.sync()
+            if notificationStatus == .notDetermined {
+                await requestNotificationPermission()
+            }
+        }
+
+        Task {
+            await enqueueRegistration(token: token).value
             await sync?.refreshKeys()
             await ensureDefaultKey()
+            await sync?.sync()
         }
     }
 


### PR DESCRIPTION
On first launch the permission pop-up only appeared after tapping a button on the empty state, and the default key was created last in the boot chain, after registration, a permission check, and a full sync. The permission request now runs immediately at launch when it has never been answered, and the key is created right after device registration, before the first sync. Both xcodebuild schemes pass; no automated tests by repo decision.