### PR TITLE
Stop wrangler dev rewriting the request host

### DIFF
--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -7,6 +7,18 @@ compatibility_date = "2026-07-01"
 compatibility_flags = ["nodejs_compat"]
 routes = [{ pattern = "notifi.it", custom_domain = true }]
 
+# Without this, `wrangler dev` takes the hostname from the route above and
+# rewrites both the request URL and the Host header to notifi.it, while still
+# serving over http. Two things then break: src/index.ts stops recognising the
+# request as loopback and 301s to https in a loop, and the signature canonical
+# string in src/lib/signature.ts binds the host, so it can never match what the
+# app signed.
+# The port is pinned because the app's Debug build hard-codes it in
+# apps/app/project.yml; the two must agree.
+[dev]
+host = "localhost:8787"
+port = 8787
+
 # The marketing site. Static files are served straight from ./public for any
 # path that matches a file; every other request falls through to the Worker, so
 # /send, /keys, /devices and /history are untouched.

--- a/apps/api/wrangler.toml
+++ b/apps/api/wrangler.toml
@@ -7,14 +7,6 @@ compatibility_date = "2026-07-01"
 compatibility_flags = ["nodejs_compat"]
 routes = [{ pattern = "notifi.it", custom_domain = true }]
 
-# Without this, `wrangler dev` takes the hostname from the route above and
-# rewrites both the request URL and the Host header to notifi.it, while still
-# serving over http. Two things then break: src/index.ts stops recognising the
-# request as loopback and 301s to https in a loop, and the signature canonical
-# string in src/lib/signature.ts binds the host, so it can never match what the
-# app signed.
-# The port is pinned because the app's Debug build hard-codes it in
-# apps/app/project.yml; the two must agree.
 [dev]
 host = "localhost:8787"
 port = 8787


### PR DESCRIPTION
Local `make dev` returned a 301 redirect loop on every Worker route, so the iOS Debug build failed each request with `NSURLErrorDomain -1007` and showed the offline banner. `wrangler dev` takes its hostname from the `routes` entry, so it rewrote the request URL and Host header to notifi.it while still serving over http, which defeated the loopback test in the https-upgrade middleware. The same rewrite also made signature verification impossible, since the canonical string binds the host and the app signs `localhost:8787`. Setting the dev host fixes the cause, so both checks work unchanged; the port is pinned so a collision fails loudly instead of silently breaking signatures again. `[dev]` is read only by `wrangler dev`, and `deploy --dry-run` confirms production bindings are unchanged.

Verified locally: `curl -sD - -o /dev/null http://localhost:8787/history` returns `401 bad_signature` rather than a 301, and a clean install on the Simulator registers (`POST /devices 200`), loads history, and connects (`GET /socket 101`) with no offline banner. Push delivery itself was not exercised — there are no APNs secrets locally.