### PR TITLE
Open the app's own page in macOS notification settings

### DIFF
--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -508,7 +508,9 @@ final class AppModel {
             UIApplication.shared.open(url)
         }
         #else
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+        let pane = "x-apple.systempreferences:com.apple.Notifications-Settings.extension"
+        let target = Bundle.main.bundleIdentifier.map { "\(pane)?id=\($0)" } ?? pane
+        if let url = URL(string: target) {
             NSWorkspace.shared.open(url)
         }
         #endif


### PR DESCRIPTION
Tapping "Open notification settings" on macOS opened the notifications root and left you to find notifi in the app list, because the URL used the legacy pane id with no anchor. The modern pane extension takes the app as a query anchor, so it now opens straight onto notifi's page — Allow notifications, Alert Style, Time Sensitive, Critical alerts.

```
x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=<bundleID>
```

The anchor format is confirmed against the extension's own logging, not guessed: `?<bundleID>`, `?bundleIdentifier=` and `?app=` each log `unknown navigation key`, while `?id=<bundleID>` logs `revealElement: local bundleIdentifier: it.notifi.notifi`. Both schemes build; the button wiring itself is unexercised, since launching a Debug macOS build clobbers the installed app's APNs token.