### PR TITLE
Trade two floor keywords for the two Apple rates higher

### DIFF
--- a/apps/app/fastlane/metadata/en-GB/keywords.txt
+++ b/apps/app/fastlane/metadata/en-GB/keywords.txt
@@ -1,1 +1,1 @@
-webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,uptime,ssh,docker,http
+webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,ssh,docker,terminal,developer

--- a/apps/app/fastlane/metadata/en-US/keywords.txt
+++ b/apps/app/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,uptime,ssh,docker,http
+webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,ssh,docker,terminal,developer


### PR DESCRIPTION
Apple's popularity index, read for both the GB and US storefronts, puts `terminal` and `developer` at 3 on its 0–5 scale, alongside `ssh` and `push`. Every notification word the listing indexes — `notification`, `notifications`, `notify`, `push notifications`, `webhook`, `api` — sits at the floor of 1, as do `server`, `script`, `cron`, `curl`, `monitor` and `pager`. Both terms were in the keyword field before and were cut on a search-intent argument the numbers do not support.

`http` goes because its demand is VPN tooling (autocomplete answers it with "http injector", "http custom"), and `uptime` goes because the app monitors nothing — it receives what other things send.

| | Keywords (en-GB, en-US) |
|---|---|
| Before | `webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,uptime,ssh,docker,http` (89) |
| After | `webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,ssh,docker,terminal,developer` (96) |

English only — the other four locales index their own words and none have been measured. Deliberately not taken: `shortcuts`, the one term scoring 4, because the app ships no App Intents and would be answering a search for something it does not do.