### PR TITLE
Name the release DMG after the version it contains

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -187,5 +187,5 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
-            apps/app/build/updates/notifi.dmg \
+            "apps/app/build/updates/notifi-${MARKETING_VERSION}.dmg" \
             apps/app/build/updates/appcast.xml

--- a/apps/api/src/routes/downloads.ts
+++ b/apps/api/src/routes/downloads.ts
@@ -3,8 +3,27 @@ import type { AppEnv } from '../types.js';
 
 export const downloads = new Hono<AppEnv>();
 
-const LATEST = 'https://github.com/notifi-it/notifi/releases/latest/download';
+const RELEASES = 'https://github.com/notifi-it/notifi/releases';
 
-downloads.get('/download/mac', (c) => c.redirect(`${LATEST}/notifi.dmg`, 302));
+async function latestTag(): Promise<string | null> {
+  try {
+    const res = await fetch(`${RELEASES}/latest`, {
+      redirect: 'manual',
+      signal: AbortSignal.timeout(3000),
+      cf: { cacheEverything: true, cacheTtl: 300 },
+    });
+    return res.headers.get('location')?.match(/\/releases\/tag\/(v[^/?#]+)$/)?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
 
-downloads.get('/download/appcast.xml', (c) => c.redirect(`${LATEST}/appcast.xml`, 302));
+downloads.get('/download/mac', async (c) => {
+  const tag = await latestTag();
+  if (!tag) return c.redirect(`${RELEASES}/latest`, 302);
+  return c.redirect(`${RELEASES}/download/${tag}/notifi-${tag.slice(1)}.dmg`, 302);
+});
+
+downloads.get('/download/appcast.xml', (c) =>
+  c.redirect(`${RELEASES}/latest/download/appcast.xml`, 302),
+);

--- a/apps/app/fastlane/Fastfile
+++ b/apps/app/fastlane/Fastfile
@@ -526,13 +526,14 @@ platform :mac do
     # generate_appcast signs each entry with the EdDSA key held in the login
     # Keychain under the "notifi" account -- deliberately not the default
     # account, which holds a different app's key.
-    # The asset is named notifi.dmg, not notifi-<version>.dmg, so that
-    # /releases/latest/download/notifi.dmg is a stable link the website can use.
-    # Per-version URLs stay unique because the tag is in the path, and Sparkle
-    # reads the version out of the app bundle, not the filename.
+    # generate_appcast writes one entry per DMG it finds in the directory and
+    # takes the enclosure filename from the file, so the directory is emptied
+    # first: a versioned name no longer overwrites the previous run's, and a
+    # second local build would otherwise publish an appcast describing both.
     updates = File.expand_path("../build/updates", __dir__)
+    sh("rm", "-rf", updates)
     sh("mkdir", "-p", updates)
-    sh("cp", dmg, "#{updates}/notifi.dmg")
+    sh("cp", dmg, updates)
 
     prefix = "https://github.com/notifi-it/notifi/releases/download/v#{version}/"
     if ENV["SPARKLE_ED_PRIVATE_KEY"]
@@ -560,7 +561,7 @@ platform :mac do
 
     # The lane stops at the artifacts. Publishing is one `gh release create` in
     # the release-macos job, which is also the thing that has a token.
-    UI.success("==> #{updates}/notifi.dmg")
+    UI.success("==> #{updates}/#{File.basename(dmg)}")
     UI.success("==> #{appcast}")
   end
 

--- a/docs/SHIPPING.md
+++ b/docs/SHIPPING.md
@@ -10,7 +10,7 @@ flowchart TB
     prod["production<br/>migrate notifi-prod<br/>then wrangler deploy"]
     tf["testflight job<br/>uploads to TestFlight<br/>dead end, not the store"]
     mac["release-macos job<br/>fastlane mac dmg<br/>notarizes and signs the feed"]
-    ghr["GitHub release<br/>notifi.dmg, appcast.xml<br/>Sparkle and the site read it"]
+    ghr["GitHub release<br/>notifi-&lt;version&gt;.dmg, appcast.xml<br/>Sparkle and the site read it"]
     mac --> ghr
   end
 
@@ -54,10 +54,13 @@ The tag runs [app.yml](../.github/workflows/app.yml):
 
 - iOS is archived and uploaded to TestFlight.
 - macOS is built and notarized by the fastlane `dmg` lane, then attached to a
-  GitHub release as `notifi.dmg` and `appcast.xml`. The app's `SUFeedURL` is
-  `https://notifi.it/download/appcast.xml` and the website links
-  `/download/mac`; both are Worker redirects to the latest release's assets, so
-  neither URL has to change on a release.
+  GitHub release as `notifi-<version>.dmg` and `appcast.xml`. The app's
+  `SUFeedURL` is `https://notifi.it/download/appcast.xml` and the website links
+  `/download/mac`; both are Worker redirects, so neither URL has to change on a
+  release. `appcast.xml` keeps a fixed name and redirects straight to
+  `releases/latest/download`; the DMG does not, so `/download/mac` reads the tag
+  out of the `releases/latest` redirect first and falls back to the releases
+  page if GitHub does not answer.
 
 ## The App Store submission is not the TestFlight build
 


### PR DESCRIPTION
The asset was `notifi.dmg` so `/releases/latest/download/notifi.dmg` was a fixed URL the Worker could redirect to without knowing the version, at the cost of a download that says nothing about which version it is. `/download/mac` now reads the tag out of the `releases/latest` redirect and sends the visitor to that tag's `notifi-<version>.dmg`, cached at the edge for five minutes and falling back to the releases page if GitHub does not answer within three seconds. `appcast.xml` keeps its fixed name and direct redirect, since Sparkle takes the enclosure URL from the appcast and the version from the app bundle. The lane now empties its build directory first, because a versioned name no longer overwrites the previous run's and `generate_appcast` would describe both.

**Ordering:** merging deploys the Worker immediately and `/download/mac` will resolve to `v2.0.8/notifi-2.0.8.dmg`, which does not exist, so the download button 404s until a release ships under the new name — fix by first uploading a copy of the v2.0.8 DMG under the versioned name, additively, leaving the existing `notifi.dmg` for the published 2.0.8 appcast entry.