### PR TITLE
Put the listing copy back under packages/copy

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -32,10 +32,6 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @notifi/contract --filter @notifi/copy --filter @notifi/api typecheck
-      # Copy.swift is generated from packages/copy. Regenerate in memory and fail
-      # if what is committed has drifted -- the app compiles either way, so
-      # nothing else would notice.
-      - run: pnpm --filter @notifi/copy check-copy
 
   deploy-production:
     needs: check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,7 @@ jobs:
       # a bare npx fetches the newest major and fails on syntax this one accepts.
       - run: pnpm install --frozen-lockfile
       - run: node scripts/check-migrations.mjs
+      # check-copy generates into apps/app, so it belongs to the same class as
+      # the comment linter: the api workflow's paths do not cover the files it
+      # writes, and a PR that edits one of them directly would never run it.
+      - run: pnpm --filter @notifi/copy check-copy

--- a/packages/copy/scripts/gen-copy.ts
+++ b/packages/copy/scripts/gen-copy.ts
@@ -221,13 +221,13 @@ const STORE_LOCALES: Record<LanguageCode, string> = {
 };
 
 const STORE_SHARED: Record<string, string> = {
-  'name.txt': 'notifi',
   'marketing_url.txt': 'https://notifi.it',
   'privacy_url.txt': 'https://notifi.it/privacy',
   'support_url.txt': 'https://notifi.it',
 };
 
 const STORE_LIMITS: Record<string, number> = {
+  'name.txt': 30,
   'subtitle.txt': 30,
   'promotional_text.txt': 170,
   'keywords.txt': 100,
@@ -246,6 +246,7 @@ function storeOutputs(): Array<{ path: string; contents: string; label: string }
 
     const files: Record<string, string> = {
       ...STORE_SHARED,
+      'name.txt': s.name,
       'subtitle.txt': s.subtitle,
       'promotional_text.txt': s.promotionalText,
       'keywords.txt': s.keywords,

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -42,13 +42,14 @@ export const copy = {
   },
 
   store: {
-    subtitle: 'One HTTP request, one push',
+    name: 'notifi: Push Notifications',
+    subtitle: 'For scripts and servers',
     promotionalText:
       "One HTTP request, and the notification is on your iPhone or Mac. Encrypted with " +
       "your public key — we can't read your notifications. No accounts, no SDK.",
     keywords:
-      'curl,webhook,api,alert,cli,server,monitor,cron,script,developer,terminal,devops,' +
-      'homelab,uptime,pager',
+      'webhook,api,notify,alerts,self,hosted,cron,curl,cli,devops,homelab,ssh,docker,' +
+      'terminal,developer',
     description:
       'Push notifications for your scripts and servers.\n\n' +
       'Create a send key and send a title and a body to notifi.it in one HTTP request. ' +

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -35,14 +35,15 @@ export const de: Translation = {
     'Nicht gesendet. Dieses Gerät ist so eingestellt, dass es eine nicht wie geschrieben zustellbare Nachricht ablehnt.',
 
 
-  'store.subtitle': 'Eine Anfrage, ein Push',
+  'store.name': 'notifi: Benachrichtigungen',
+  'store.subtitle': 'Für Skripte und Server',
   'store.promotionalText':
     'Eine HTTP-Anfrage, und sie landet auf deinem iPhone oder Mac. Mit deinem ' +
     'öffentlichen Schlüssel verschlüsselt — wir können sie nicht lesen. ' +
     'Kein Account, kein SDK.',
   'store.keywords':
-    'curl,webhook,api,alarm,cli,server,überwachung,cron,skript,entwickler,terminal,' +
-    'devops,homelab,pager',
+    'webhook,api,push,alarm,selbst,gehostet,cron,curl,cli,devops,homelab,ssh,docker,' +
+    'überwachung',
   'store.description':
     'Push-Benachrichtigungen für deine Skripte und Server.\n\n' +
     'Erstelle einen Sendeschlüssel und schicke einen Titel und eine Nachricht in einer ' +

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -347,13 +347,14 @@ export const es: Translation = {
   'clientErrors.transport': 'No se pudo conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.',
   'clientErrors.decoding': 'El servidor devolvió algo inesperado. Inténtalo de nuevo en un momento.',
 
-  'store.subtitle': 'Una solicitud HTTP, un aviso',
+  'store.name': 'notifi: Notificaciones push',
+  'store.subtitle': 'Para scripts y servidores',
   'store.promotionalText':
     'Una solicitud HTTP y la notificación llega a tu iPhone o Mac. Cifrado con tu clave pública: ' +
     'no podemos leer tus mensajes. Sin cuentas, sin SDK.',
   'store.keywords':
-    'curl,webhook,api,alerta,cli,servidor,monitor,cron,script,desarrollador,terminal,devops,' +
-    'homelab,pager',
+    'webhook,api,avisar,alerta,auto,alojado,cron,curl,cli,devops,homelab,ssh,docker,' +
+    'monitor',
   'store.description':
     'Notificaciones push para tus scripts y servidores.\n\n' +
     'Crea una clave de envío y manda un título y un mensaje a notifi.it en una solicitud HTTP. ' +

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -338,13 +338,14 @@ export const fr: Translation = {
     "notifi nécessite un Mac avec puce Apple silicon ou puce T2. Ce Mac n'a pas d'Enclave " +
     "sécurisée, que notifi utilise pour protéger votre clé d'identité.",
 
-  'store.subtitle': 'Une requête HTTP, un push',
+  'store.name': 'notifi : notifications push',
+  'store.subtitle': 'Pour scripts et serveurs',
   'store.promotionalText':
     'Une requête HTTP, et la notification arrive sur votre iPhone ou Mac. Chiffré avec ' +
     'votre clé publique — nous ne pouvons pas lire vos messages. Pas de compte, pas de SDK.',
   'store.keywords':
-    'curl,webhook,api,alerte,cli,serveur,monitoring,cron,script,dev,terminal,devops,' +
-    'homelab,pager',
+    'webhook,api,avertir,alerte,auto,hébergé,cron,curl,cli,devops,homelab,ssh,docker,' +
+    'monitor',
   'store.description':
     'Notifications push pour vos scripts et serveurs.\n\n' +
     "Créez une clé d'envoi et envoyez un titre et un message à notifi.it en une seule " +

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -347,13 +347,14 @@ export const it: Translation = {
   'clientErrors.transport': 'Impossibile raggiungere il server. Controlla la connessione e riprova.',
   'clientErrors.decoding': 'Il server ha restituito qualcosa di inatteso. Riprova tra un momento.',
 
-  'store.subtitle': 'Una richiesta, dritta in tasca',
+  'store.name': 'notifi: notifiche push',
+  'store.subtitle': 'Per script e server',
   'store.promotionalText':
     'Una richiesta HTTP e la notifica arriva sul tuo iPhone o Mac. Cifrato con la tua chiave ' +
     'pubblica: non possiamo leggere i tuoi messaggi. Niente account, niente SDK.',
   'store.keywords':
-    'curl,webhook,api,notifica,avviso,cli,server,monitor,cron,script,sviluppatore,devops,' +
-    'homelab,pager',
+    'webhook,api,avvisare,allerta,auto,ospitato,cron,curl,cli,devops,homelab,ssh,docker,' +
+    'monitor',
   'store.description':
     'Notifiche push per i tuoi script e server.\n\n' +
     'Crea una chiave di invio e manda un titolo e un messaggio a notifi.it in un\'unica richiesta ' +


### PR DESCRIPTION
PRs #255 and #261 edited the generated fastlane metadata directly, so `packages/copy` still held the name, subtitle and keywords the listing had before either, and `make gen-copy` would have reverted both. Every value here is lifted from the committed file, so nothing a reader sees changes and a regeneration is now a no-op; the name becomes per-locale rather than a shared `notifi`, since all five locales carry a translated one, and it picks up the 30-character limit the other indexed fields already have. `check-copy` moves to the lint workflow, which is where this repo already puts checks that read across apps — the api workflow only runs on `apps/api`, `packages/contract` and `packages/copy`, so neither PR that caused the drift ever ran it.

Blocks [#262](https://github.com/notifi-it/notifi/pull/262): `deploy-production` needs `check`, so while this fails, merging anything under `apps/api` lands the code without deploying the Worker.