### PR TITLE
Run locally against a dev server on a random port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,32 @@ Two things the generator will not do for you:
 - **Backfills and renames.** A diff cannot infer intent, so a correlated update
   or a column rename has to be written by hand — and said so in the commit.
 
+## Running the app against a local server
+
+`make dev` starts wrangler on a random free port so parallel worktrees never
+collide; read the port off its "Ready on" line. It passes `--host` alongside
+`--port` because the signed canonical string binds host **and** port — a bare
+`wrangler dev --port N` leaves the Worker verifying `localhost:8787` and every
+signed request 401s.
+
+The Worker needs `apps/api/.dev.vars` (gitignored): `ENCRYPTION_KEY` as 64 hex
+chars, plus `APNS_TEAM_ID`/`APNS_KEY_ID`/`APNS_PRIVATE_KEY` stubs. Run
+`make migrate` once per worktree. APNs cannot deliver locally — the push
+attempt fails on the stub key every time. Arrivals still reach a running app
+over the socket, and the banner comes from the app's own unpushed announce.
+
+Point a DEBUG build at it with `NOTIFI_BASE_URL=http://localhost:<port>`.
+Setting it flips the app into local-dev isolation (`LocalDev`): in-memory
+message store, wiped-per-launch defaults suite for sync state and link policy,
+key cache neither read nor written. Without that isolation the Debug build
+shares the installed app's store and its `lastSyncedDeviceSeq` cursor sits at
+the production sequence, so history from a fresh local D1 (seq 1..n) is
+permanently invisible — sends look accepted but never appear.
+
+Seed sendable keys with `apps/api/seed-keys.mjs` (prints the secrets, writes
+`/tmp/notifi-seed.sql` to apply with `wrangler d1 execute --local`), using the
+device row the app registers on first launch.
+
 ## Building the app
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,12 +115,13 @@ attempt fails on the stub key every time. Arrivals still reach a running app
 over the socket, and the banner comes from the app's own unpushed announce.
 
 Point a DEBUG build at it with `NOTIFI_BASE_URL=http://localhost:<port>`.
-Setting it flips the app into local-dev isolation (`LocalDev`): in-memory
-message store, wiped-per-launch defaults suite for sync state and link policy,
-key cache neither read nor written. Without that isolation the Debug build
-shares the installed app's store and its `lastSyncedDeviceSeq` cursor sits at
-the production sequence, so history from a fresh local D1 (seq 1..n) is
-permanently invisible — sends look accepted but never appear.
+Setting it flips the app into local-dev isolation (`LocalDev.isActive`): the
+message store goes in-memory, and because the sync cursor lives *inside* the
+store (`SyncState`), it dies with it — the link-policy allow-list and key
+cache are simply not read or persisted. Without that isolation the Debug
+build shares the installed app's store, whose cursor sits at the production
+sequence, so history from a fresh local D1 (seq 1..n) is permanently
+invisible — sends look accepted but never appear.
 
 Seed sendable keys with `apps/api/seed-keys.mjs` (prints the secrets, writes
 `/tmp/notifi-seed.sql` to apply with `wrangler d1 execute --local`), using the

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,12 @@
 	app-project app-preflight app-dmg app-testflight app-submit app-appstore \
 	app-metadata app-metadata-check app-screenshots app-resubmit shots screens screens-mac
 
+# Random port so parallel worktrees never collide. The signed canonical string
+# binds the host, so --host must carry the same port as --port; the pinned
+# [dev] block in wrangler.toml only covers running `wrangler dev` bare.
 dev:
-	cd apps/api && pnpm wrangler dev
+	cd apps/api && port=$$(node -e 'const s=require("net").createServer();s.listen(0,()=>{console.log(s.address().port);s.close()})') && \
+		pnpm wrangler dev --port $$port --host localhost:$$port
 
 deploy:
 	cd apps/api && pnpm wrangler deploy

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -129,7 +129,7 @@ final class AppModel {
         remoteImagesEnabled = RemoteImages.isEnabled
         appearance = Appearance(rawValue: UserDefaults.standard.string(forKey: Self.appearanceKey) ?? "")
             ?? .dark
-        keysAllowingAnyLink = LinkPolicy.allowedKeyIDs()
+        keysAllowingAnyLink = LocalDev.isActive ? [] : LinkPolicy.allowedKeyIDs()
     }
 
     func allowsAnyLink(keyID: Int?) -> Bool {
@@ -143,7 +143,7 @@ final class AppModel {
         } else {
             keysAllowingAnyLink.remove(keyID)
         }
-        LinkPolicy.store(keysAllowingAnyLink)
+        if !LocalDev.isActive { LinkPolicy.store(keysAllowingAnyLink) }
     }
 
     var baseURL: URL {
@@ -411,7 +411,7 @@ final class AppModel {
     }
 
     private func openLink(_ url: URL, keyID: Int?, serverID: Int) {
-        guard LinkPolicy.allows(url, keyID: keyID) else {
+        guard LinkPolicy.allows(url, anyScheme: allowsAnyLink(keyID: keyID)) else {
             handleTap(serverID: serverID)
             return
         }

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -147,12 +147,9 @@ final class AppModel {
     }
 
     var baseURL: URL {
-        #if DEBUG
-        if let raw = ProcessInfo.processInfo.environment["NOTIFI_BASE_URL"],
-           let url = URL(string: raw), url.host != nil {
+        if let url = LocalDev.baseURL {
             return url
         }
-        #endif
         if let raw = Bundle.main.object(forInfoDictionaryKey: "API_BASE_URL") as? String,
            let url = URL(string: raw), url.host != nil {
             return url

--- a/apps/app/Shared/NotifiApp.swift
+++ b/apps/app/Shared/NotifiApp.swift
@@ -30,7 +30,7 @@ struct NotifiApp: App {
     static func makeContainer() -> ModelContainer {
         do {
             #if DEBUG
-            if SampleData.isEnabled {
+            if SampleData.isEnabled || LocalDev.isActive {
                 let config = ModelConfiguration(isStoredInMemoryOnly: true)
                 return try ModelContainer(for: Message.self, configurations: config)
             }

--- a/apps/app/Shared/NotifiApp.swift
+++ b/apps/app/Shared/NotifiApp.swift
@@ -32,10 +32,10 @@ struct NotifiApp: App {
             #if DEBUG
             if SampleData.isEnabled || LocalDev.isActive {
                 let config = ModelConfiguration(isStoredInMemoryOnly: true)
-                return try ModelContainer(for: Message.self, configurations: config)
+                return try ModelContainer(for: Message.self, SyncState.self, configurations: config)
             }
             #endif
-            let container = try ModelContainer(for: Message.self)
+            let container = try ModelContainer(for: Message.self, SyncState.self)
             if let url = container.configurations.first?.url {
                 OnDiskProtection.protect(url)
             }

--- a/apps/app/Shared/Store/CachedKey.swift
+++ b/apps/app/Shared/Store/CachedKey.swift
@@ -62,7 +62,8 @@ enum KeyCacheStore {
     }
 
     static func load() -> [CachedKey] {
-        guard let data = try? Data(contentsOf: fileURL),
+        guard !LocalDev.isActive,
+              let data = try? Data(contentsOf: fileURL),
               let keys = try? JSONDecoder().decode([CachedKey].self, from: data) else {
             return []
         }
@@ -70,6 +71,7 @@ enum KeyCacheStore {
     }
 
     static func save(_ keys: [CachedKey]) {
+        guard !LocalDev.isActive else { return }
         guard let data = try? JSONEncoder().encode(keys) else { return }
         #if os(iOS)
         try? data.write(to: fileURL, options: [.atomic, .completeFileProtectionUnlessOpen])

--- a/apps/app/Shared/Store/SyncEngine.swift
+++ b/apps/app/Shared/Store/SyncEngine.swift
@@ -17,10 +17,7 @@ final class SyncEngine {
     private(set) var isSyncing = false
     private(set) var unread = 0
 
-    private static let legacyBookmarkKey = "lastSyncedDeviceSeq"
-    private static let legacyFailureKeyPrefix = "ingestFailedAt."
     private static let unreadableGraceSeconds: TimeInterval = 14 * 24 * 60 * 60
-    private static let seqMigrationKey = "didMigrateToDeviceSeq"
     private static let pageSize = 200
     private static let maxPagesPerSync = 50
 
@@ -29,37 +26,11 @@ final class SyncEngine {
         self.identity = identity
         self.context = context
         self.keys = KeyCacheStore.load()
-        migrateToDeviceSeqIfNeeded()
     }
 
     static func summaryKeys(_ keys: [CachedKey]) -> [NotificationCategories.SummaryKey] {
         keys.filter { !$0.isRevoked }
             .map { NotificationCategories.SummaryKey(id: $0.id, name: $0.name) }
-    }
-
-    private func migrateToDeviceSeqIfNeeded() {
-        guard !LocalDev.isActive else { return }
-        let defaults = UserDefaults.standard
-        guard !defaults.bool(forKey: Self.seqMigrationKey) else { return }
-
-        if let existing = try? context.fetch(FetchDescriptor<Message>()) {
-            for message in existing where message.serverID > 0 {
-                message.serverID = -message.serverID
-            }
-            do {
-                try context.save()
-            } catch {
-                log.error("device_seq migration failed: \(String(describing: error), privacy: .public)")
-                return
-            }
-        }
-
-        for key in defaults.dictionaryRepresentation().keys
-        where key.hasPrefix(Self.legacyFailureKeyPrefix) {
-            defaults.removeObject(forKey: key)
-        }
-        defaults.removeObject(forKey: "lastSyncedMessageID")
-        defaults.set(true, forKey: Self.seqMigrationKey)
     }
 
     private var cachedState: SyncState?
@@ -71,15 +42,6 @@ final class SyncEngine {
             return existing
         }
         let fresh = SyncState()
-        if !LocalDev.isActive {
-            let defaults = UserDefaults.standard
-            fresh.bookmark = defaults.integer(forKey: Self.legacyBookmarkKey)
-            defaults.removeObject(forKey: Self.legacyBookmarkKey)
-            for key in defaults.dictionaryRepresentation().keys
-            where key.hasPrefix(Self.legacyFailureKeyPrefix) {
-                defaults.removeObject(forKey: key)
-            }
-        }
         context.insert(fresh)
         try? context.save()
         cachedState = fresh

--- a/apps/app/Shared/Store/SyncEngine.swift
+++ b/apps/app/Shared/Store/SyncEngine.swift
@@ -17,8 +17,8 @@ final class SyncEngine {
     private(set) var isSyncing = false
     private(set) var unread = 0
 
-    private let bookmarkKey = "lastSyncedDeviceSeq"
-    private let failureKeyPrefix = "ingestFailedAt."
+    private static let legacyBookmarkKey = "lastSyncedDeviceSeq"
+    private static let legacyFailureKeyPrefix = "ingestFailedAt."
     private static let unreadableGraceSeconds: TimeInterval = 14 * 24 * 60 * 60
     private static let seqMigrationKey = "didMigrateToDeviceSeq"
     private static let pageSize = 200
@@ -38,7 +38,8 @@ final class SyncEngine {
     }
 
     private func migrateToDeviceSeqIfNeeded() {
-        let defaults = LocalDev.defaults
+        guard !LocalDev.isActive else { return }
+        let defaults = UserDefaults.standard
         guard !defaults.bool(forKey: Self.seqMigrationKey) else { return }
 
         if let existing = try? context.fetch(FetchDescriptor<Message>()) {
@@ -53,16 +54,41 @@ final class SyncEngine {
             }
         }
 
-        for key in defaults.dictionaryRepresentation().keys where key.hasPrefix(failureKeyPrefix) {
+        for key in defaults.dictionaryRepresentation().keys
+        where key.hasPrefix(Self.legacyFailureKeyPrefix) {
             defaults.removeObject(forKey: key)
         }
         defaults.removeObject(forKey: "lastSyncedMessageID")
         defaults.set(true, forKey: Self.seqMigrationKey)
     }
 
+    private var cachedState: SyncState?
+
+    private var state: SyncState {
+        if let cachedState { return cachedState }
+        if let existing = try? context.fetch(FetchDescriptor<SyncState>()).first {
+            cachedState = existing
+            return existing
+        }
+        let fresh = SyncState()
+        if !LocalDev.isActive {
+            let defaults = UserDefaults.standard
+            fresh.bookmark = defaults.integer(forKey: Self.legacyBookmarkKey)
+            defaults.removeObject(forKey: Self.legacyBookmarkKey)
+            for key in defaults.dictionaryRepresentation().keys
+            where key.hasPrefix(Self.legacyFailureKeyPrefix) {
+                defaults.removeObject(forKey: key)
+            }
+        }
+        context.insert(fresh)
+        try? context.save()
+        cachedState = fresh
+        return fresh
+    }
+
     private var bookmark: Int {
-        get { LocalDev.defaults.integer(forKey: bookmarkKey) }
-        set { LocalDev.defaults.set(newValue, forKey: bookmarkKey) }
+        get { state.bookmark }
+        set { state.bookmark = newValue }
     }
 
     func sync() async {
@@ -99,12 +125,13 @@ final class SyncEngine {
                 }
 
                 let arrived = newMessages > insertedBefore
+                let advanced = ackable > bookmark
+                if advanced { bookmark = ackable }
                 try withAnimation(arrived && !Theme.reduceMotion ? Theme.reveal : nil) {
                     try context.save()
                 }
 
-                guard ackable > bookmark else { break pages }
-                bookmark = ackable
+                guard advanced else { break pages }
                 if blocked { break pages }
                 if page.messages.count < Self.pageSize { break }
             }
@@ -264,22 +291,22 @@ final class SyncEngine {
     }
 
     private func unreadableOrGiveUp(_ serverID: Int, reason: String) -> IngestResult {
-        let key = "\(failureKeyPrefix)\(serverID)"
-        let firstSeen = LocalDev.defaults.object(forKey: key) as? Double
-        guard let firstSeen else {
-            LocalDev.defaults.set(Date().timeIntervalSince1970, forKey: key)
+        let key = String(serverID)
+        guard let firstSeen = state.failureFirstSeen[key] else {
+            state.failureFirstSeen[key] = Date().timeIntervalSince1970
             return .unreadable
         }
         if Date().timeIntervalSince1970 - firstSeen > Self.unreadableGraceSeconds {
             log.error("giving up on message \(serverID) after grace period: \(reason, privacy: .public)")
-            LocalDev.defaults.removeObject(forKey: key)
+            state.failureFirstSeen[key] = nil
             return .discarded
         }
         return .unreadable
     }
 
     private func clearFailure(_ serverID: Int) {
-        LocalDev.defaults.removeObject(forKey: "\(failureKeyPrefix)\(serverID)")
+        guard state.failureFirstSeen[String(serverID)] != nil else { return }
+        state.failureFirstSeen[String(serverID)] = nil
     }
 
     func refreshKeys() async {

--- a/apps/app/Shared/Store/SyncEngine.swift
+++ b/apps/app/Shared/Store/SyncEngine.swift
@@ -38,7 +38,7 @@ final class SyncEngine {
     }
 
     private func migrateToDeviceSeqIfNeeded() {
-        let defaults = UserDefaults.standard
+        let defaults = LocalDev.defaults
         guard !defaults.bool(forKey: Self.seqMigrationKey) else { return }
 
         if let existing = try? context.fetch(FetchDescriptor<Message>()) {
@@ -61,8 +61,8 @@ final class SyncEngine {
     }
 
     private var bookmark: Int {
-        get { UserDefaults.standard.integer(forKey: bookmarkKey) }
-        set { UserDefaults.standard.set(newValue, forKey: bookmarkKey) }
+        get { LocalDev.defaults.integer(forKey: bookmarkKey) }
+        set { LocalDev.defaults.set(newValue, forKey: bookmarkKey) }
     }
 
     func sync() async {
@@ -265,21 +265,21 @@ final class SyncEngine {
 
     private func unreadableOrGiveUp(_ serverID: Int, reason: String) -> IngestResult {
         let key = "\(failureKeyPrefix)\(serverID)"
-        let firstSeen = UserDefaults.standard.object(forKey: key) as? Double
+        let firstSeen = LocalDev.defaults.object(forKey: key) as? Double
         guard let firstSeen else {
-            UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: key)
+            LocalDev.defaults.set(Date().timeIntervalSince1970, forKey: key)
             return .unreadable
         }
         if Date().timeIntervalSince1970 - firstSeen > Self.unreadableGraceSeconds {
             log.error("giving up on message \(serverID) after grace period: \(reason, privacy: .public)")
-            UserDefaults.standard.removeObject(forKey: key)
+            LocalDev.defaults.removeObject(forKey: key)
             return .discarded
         }
         return .unreadable
     }
 
     private func clearFailure(_ serverID: Int) {
-        UserDefaults.standard.removeObject(forKey: "\(failureKeyPrefix)\(serverID)")
+        LocalDev.defaults.removeObject(forKey: "\(failureKeyPrefix)\(serverID)")
     }
 
     func refreshKeys() async {

--- a/apps/app/Shared/Store/SyncState.swift
+++ b/apps/app/Shared/Store/SyncState.swift
@@ -1,0 +1,13 @@
+import Foundation
+import SwiftData
+
+@Model
+final class SyncState {
+    var bookmark: Int
+    var failureFirstSeen: [String: Double]
+
+    init(bookmark: Int = 0, failureFirstSeen: [String: Double] = [:]) {
+        self.bookmark = bookmark
+        self.failureFirstSeen = failureFirstSeen
+    }
+}

--- a/apps/app/Shared/Support/LinkPolicy.swift
+++ b/apps/app/Shared/Support/LinkPolicy.swift
@@ -7,15 +7,15 @@ enum LinkPolicy {
         anyScheme || url.scheme?.lowercased() == "https"
     }
 
-    static func allowedKeyIDs() -> Set<Int> {
-        Set(UserDefaults.standard.array(forKey: defaultsKey) as? [Int] ?? [])
+    @MainActor static func allowedKeyIDs() -> Set<Int> {
+        Set(LocalDev.defaults.array(forKey: defaultsKey) as? [Int] ?? [])
     }
 
-    static func store(_ keyIDs: Set<Int>) {
-        UserDefaults.standard.set(keyIDs.sorted(), forKey: defaultsKey)
+    @MainActor static func store(_ keyIDs: Set<Int>) {
+        LocalDev.defaults.set(keyIDs.sorted(), forKey: defaultsKey)
     }
 
-    static func allows(_ url: URL, keyID: Int?) -> Bool {
+    @MainActor static func allows(_ url: URL, keyID: Int?) -> Bool {
         guard let keyID else { return allows(url, anyScheme: false) }
         return allows(url, anyScheme: allowedKeyIDs().contains(keyID))
     }

--- a/apps/app/Shared/Support/LinkPolicy.swift
+++ b/apps/app/Shared/Support/LinkPolicy.swift
@@ -7,16 +7,11 @@ enum LinkPolicy {
         anyScheme || url.scheme?.lowercased() == "https"
     }
 
-    @MainActor static func allowedKeyIDs() -> Set<Int> {
-        Set(LocalDev.defaults.array(forKey: defaultsKey) as? [Int] ?? [])
+    static func allowedKeyIDs() -> Set<Int> {
+        Set(UserDefaults.standard.array(forKey: defaultsKey) as? [Int] ?? [])
     }
 
-    @MainActor static func store(_ keyIDs: Set<Int>) {
-        LocalDev.defaults.set(keyIDs.sorted(), forKey: defaultsKey)
-    }
-
-    @MainActor static func allows(_ url: URL, keyID: Int?) -> Bool {
-        guard let keyID else { return allows(url, anyScheme: false) }
-        return allows(url, anyScheme: allowedKeyIDs().contains(keyID))
+    static func store(_ keyIDs: Set<Int>) {
+        UserDefaults.standard.set(keyIDs.sorted(), forKey: defaultsKey)
     }
 }

--- a/apps/app/Shared/Support/LocalDev.swift
+++ b/apps/app/Shared/Support/LocalDev.swift
@@ -7,17 +7,8 @@ enum LocalDev {
               let url = URL(string: raw), url.host != nil else { return nil }
         return url
     }()
-
-    private static let suiteName = "it.notifi.localdev"
-
-    @MainActor static let defaults: UserDefaults = {
-        guard isActive, let suite = UserDefaults(suiteName: suiteName) else { return .standard }
-        suite.removePersistentDomain(forName: suiteName)
-        return suite
-    }()
     #else
     static let baseURL: URL? = nil
-    @MainActor static let defaults: UserDefaults = .standard
     #endif
 
     static var isActive: Bool { baseURL != nil }

--- a/apps/app/Shared/Support/LocalDev.swift
+++ b/apps/app/Shared/Support/LocalDev.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum LocalDev {
+    #if DEBUG
+    static let baseURL: URL? = {
+        guard let raw = ProcessInfo.processInfo.environment["NOTIFI_BASE_URL"],
+              let url = URL(string: raw), url.host != nil else { return nil }
+        return url
+    }()
+
+    private static let suiteName = "it.notifi.localdev"
+
+    @MainActor static let defaults: UserDefaults = {
+        guard isActive, let suite = UserDefaults(suiteName: suiteName) else { return .standard }
+        suite.removePersistentDomain(forName: suiteName)
+        return suite
+    }()
+    #else
+    static let baseURL: URL? = nil
+    @MainActor static let defaults: UserDefaults = .standard
+    #endif
+
+    static var isActive: Bool { baseURL != nil }
+}

--- a/apps/app/Shared/Support/Theme.swift
+++ b/apps/app/Shared/Support/Theme.swift
@@ -85,6 +85,7 @@ enum Theme {
     #endif
 
     static let headerBarHeight: CGFloat = 30
+    static let headerActionSpacing: CGFloat = 8
 
     static let headerBarGap: CGFloat = 20
     static let rowGap: CGFloat = 13

--- a/apps/app/Shared/Views/Components/FeedHeader.swift
+++ b/apps/app/Shared/Views/Components/FeedHeader.swift
@@ -34,7 +34,7 @@ struct FeedHeader<Trailing: View>: View {
                 }
             }
             Spacer(minLength: 8)
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.headerActionSpacing) {
                 trailing()
                 overflowMenu
             }

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -500,7 +500,9 @@ struct GeistHeader<Trailing: View>: View {
                 }
             }
             Spacer(minLength: 8)
-            trailing
+            HStack(spacing: Theme.headerActionSpacing) {
+                trailing
+            }
                 .frame(minHeight: Theme.headerBarHeight)
         }
     }
@@ -527,6 +529,6 @@ struct GeistBackBar: View {
             Spacer(minLength: 8)
             if let trailing { trailing }
         }
-        .padding(.vertical, 10)
+        .geistPageHeader()
     }
 }

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -178,11 +178,15 @@ extension View {
     @ViewBuilder
     func glassBackground(enabled: Bool = true, in shape: some Shape = Circle()) -> some View {
         if enabled {
-            if #available(iOS 26.0, macOS 26.0, *) {
+            #if os(macOS)
+            background(shape.fill(Theme.chip.opacity(0.6)))
+            #else
+            if #available(iOS 26.0, *) {
                 glassEffect(.regular, in: shape)
             } else {
                 background(shape.fill(Theme.chip.opacity(0.6)))
             }
+            #endif
         } else {
             self
         }

--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -168,7 +168,7 @@ struct MessageFeed<Empty: View>: View {
     }
 
     private func open(_ url: URL, keyID: Int?) {
-        guard LinkPolicy.allows(url, keyID: keyID) else { return }
+        guard LinkPolicy.allows(url, anyScheme: model.allowsAnyLink(keyID: keyID)) else { return }
         #if os(iOS)
         UIApplication.shared.open(url)
         #else

--- a/apps/app/Shared/Views/MessageDetailView.swift
+++ b/apps/app/Shared/Views/MessageDetailView.swift
@@ -112,7 +112,7 @@ struct MessageDetailView: View {
 
             if let message {
                 let anyScheme = model.allowsAnyLink(keyID: message.keyID)
-                HStack(spacing: 10) {
+                HStack(spacing: Theme.headerActionSpacing) {
                     if let link = message.link, LinkPolicy.allows(link, anyScheme: anyScheme) {
                         IconButton(systemName: "globe", label: Copy.Common.openLink) {
                             open(link, keyID: message.keyID)
@@ -136,8 +136,7 @@ struct MessageDetailView: View {
             }
         }
         .geistGutter()
-        .padding(.top, 22)
-        .padding(.bottom, 6)
+        .geistPageHeader()
         .background(StaticField())
     }
 

--- a/apps/app/Shared/Views/MessageDetailView.swift
+++ b/apps/app/Shared/Views/MessageDetailView.swift
@@ -390,7 +390,7 @@ struct MessageDetailView: View {
     }
 
     private func open(_ url: URL, keyID: Int?) {
-        guard LinkPolicy.allows(url, keyID: keyID) else { return }
+        guard LinkPolicy.allows(url, anyScheme: model.allowsAnyLink(keyID: keyID)) else { return }
         #if os(iOS)
         UIApplication.shared.open(url)
         #else
@@ -399,7 +399,7 @@ struct MessageDetailView: View {
     }
 
     fileprivate func downloadImage(_ url: URL, keyID: Int?) {
-        guard LinkPolicy.allows(url, keyID: keyID) else { return }
+        guard LinkPolicy.allows(url, anyScheme: model.allowsAnyLink(keyID: keyID)) else { return }
         Task {
             guard let (data, _) = try? await URLSession.shared.data(from: url) else { return }
             #if os(iOS)

--- a/apps/app/project.yml
+++ b/apps/app/project.yml
@@ -134,6 +134,7 @@ targets:
       # app's UserDefaults, which the extension does not share, so they must not
       # be called from here.
       - path: Shared/Support/LinkPolicy.swift
+      - path: Shared/Support/LocalDev.swift
       - path: Shared/Push/NotificationCategories.swift
       - path: Support/Privacy/NotificationService/PrivacyInfo.xcprivacy
     settings:
@@ -163,6 +164,7 @@ targets:
       # app's UserDefaults, which the extension does not share, so they must not
       # be called from here.
       - path: Shared/Support/LinkPolicy.swift
+      - path: Shared/Support/LocalDev.swift
       - path: Shared/Push/NotificationCategories.swift
       - path: Support/Privacy/NotificationService/PrivacyInfo.xcprivacy
     settings:

--- a/apps/app/project.yml
+++ b/apps/app/project.yml
@@ -134,7 +134,6 @@ targets:
       # app's UserDefaults, which the extension does not share, so they must not
       # be called from here.
       - path: Shared/Support/LinkPolicy.swift
-      - path: Shared/Support/LocalDev.swift
       - path: Shared/Push/NotificationCategories.swift
       - path: Support/Privacy/NotificationService/PrivacyInfo.xcprivacy
     settings:
@@ -164,7 +163,6 @@ targets:
       # app's UserDefaults, which the extension does not share, so they must not
       # be called from here.
       - path: Shared/Support/LinkPolicy.swift
-      - path: Shared/Support/LocalDev.swift
       - path: Shared/Push/NotificationCategories.swift
       - path: Support/Privacy/NotificationService/PrivacyInfo.xcprivacy
     settings:


### PR DESCRIPTION
`make dev` now picks a random free port and passes `--host` in lockstep with `--port`, so parallel worktrees can each run a local server without the signed canonical string breaking (#254 pinned both for exactly that reason).

Setting `NOTIFI_BASE_URL` flips a Debug build into local-dev isolation: the message store goes in-memory, and because the sync cursor now lives inside the store as a `SyncState` row it dies with it, while the link-policy allow-list and key cache are simply not read or persisted. Previously the Debug build shared the installed app's store and its production-level cursor, so history from a fresh local D1 was permanently invisible — sends returned 202 and never appeared; the old defaults-based cursor and the pre-device_seq migration are deleted rather than migrated, so an existing install resyncs once from zero.

The header action buttons also stop drifting between screens — one `Theme.headerActionSpacing` constant governs every trailing cluster and both back bars route through `geistPageHeader()` — and on macOS they trade the Liquid Glass circles for the flat chip fill the app already ships on pre-26 systems. Filed from a CLI that can't upload images — header before/after screenshots attached via the web UI.