### PR TITLE
Stop faking an APNs token when the device never got one

### DIFF
--- a/apps/api/src/routes/devices.ts
+++ b/apps/api/src/routes/devices.ts
@@ -43,8 +43,12 @@ devices.post('/devices', async (c) => {
     );
   }
 
-  const tokenHmac = await tokenHmacHex(c.env, parsed.apns_token);
-  const apnsEnc = await encryptField(c.env, parsed.apns_token);
+  const tokenHmac = parsed.apns_token
+    ? await tokenHmacHex(c.env, parsed.apns_token)
+    : `none:${parsed.public_key}`;
+  const apnsEnc = parsed.apns_token
+    ? await encryptField(c.env, parsed.apns_token)
+    : '';
   const platformEnc = await encryptPadded(c.env, parsed.platform);
   const versionEnc = await encryptPadded(c.env, parsed.app_version);
 

--- a/apps/app/Shared/API/ContractModels.swift
+++ b/apps/app/Shared/API/ContractModels.swift
@@ -3,7 +3,7 @@ import Foundation
 struct RegisterDeviceBody: Codable, Sendable {
     let publicKey: String
     let encryptionPublicKey: String
-    let apnsToken: String
+    let apnsToken: String?
     let platform: String
     let appVersion: String
 

--- a/apps/app/Shared/AppModel.swift
+++ b/apps/app/Shared/AppModel.swift
@@ -115,6 +115,7 @@ final class AppModel {
     private var context: ModelContext?
     private var pendingToken: String?
     private var registrationChain: Task<Void, Never>?
+    private var hasRegistered = false
     private var lastRegisteredToken: String?
     private let log = Logger(subsystem: "it.notifi.notifi", category: "app")
 
@@ -334,9 +335,8 @@ final class AppModel {
     private func registerDevice(token: String?) async {
         guard let api, let identity else { return }
         if let token { UserDefaults.standard.set(token, forKey: Self.realTokenKey) }
-        let knownReal = token ?? UserDefaults.standard.string(forKey: Self.realTokenKey)
-        let apnsToken = knownReal ?? Self.syntheticToken(for: identity)
-        guard apnsToken != lastRegisteredToken else { return }
+        let apnsToken = token ?? UserDefaults.standard.string(forKey: Self.realTokenKey)
+        guard !hasRegistered || apnsToken != lastRegisteredToken else { return }
         let body = RegisterDeviceBody(
             publicKey: identity.publicKeyX963.base64EncodedString(),
             encryptionPublicKey: identity.encryptionPublicKeyX963.base64EncodedString(),
@@ -347,14 +347,11 @@ final class AppModel {
         do {
             let response = try await api.registerDevice(body)
             if let strict = response.strictSend { strictSend = strict == 1 }
+            hasRegistered = true
             lastRegisteredToken = apnsToken
         } catch {
             log.error("device registration failed: \(String(describing: error), privacy: .private)")
         }
-    }
-
-    private static func syntheticToken(for identity: DeviceIdentity) -> String {
-        SHA256.hash(data: identity.publicKeyX963).map { String(format: "%02x", $0) }.joined()
     }
 
     func handleForegroundPush() {

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -67,7 +67,7 @@ export const registerDeviceBody = z
   .object({
     public_key: z.string(),
     encryption_public_key: z.string(),
-    apns_token: z.string().min(1),
+    apns_token: z.string().min(1).optional(),
     platform: z.string().min(1).max(16),
     app_version: z.string().min(1).max(16),
   })


### PR DESCRIPTION
A device that registered before APNs handed it a token used to send SHA256 of its own public key — 64 hex characters indistinguishable from a real token in the database, rejected by Apple with `400 BadDeviceToken` on every send (the cause of NOTIFI-API-7). `apns_token` is now optional in the contract, and an absent token is stored as the existing `''` sentinel with `apns_token_hmac = 'none:' || public_key`, so the row states plainly that there is no push route while staying unique against the retire-others UPDATE. The send path already short-circuits on `''`, so no migration and no delivery change. The app drops the synthetic token and registers with its cached real token or none; deduping the redundant re-register now needs an explicit `hasRegistered` flag since nil-vs-nil no longer distinguishes the first attempt. Existing stranded rows heal on the device's next registration.
