### PR TITLE
Reduce the terminal panel's corner radius

### DIFF
--- a/apps/api/public/docs.html
+++ b/apps/api/public/docs.html
@@ -322,7 +322,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
 .term{
   margin-top:40px;
   background:var(--surface);
-  border-radius:12px;overflow:hidden;
+  border-radius:8px;overflow:hidden;
 }
 .term-bar{
   display:flex;align-items:center;gap:9px;padding:9px 13px;

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -261,7 +261,7 @@ nav a:hover{color:var(--fg)}
 .term{
   margin-top:40px;
   background:var(--surface);
-  border-radius:12px;overflow:hidden;
+  border-radius:8px;overflow:hidden;
 }
 .term-bar{
   display:flex;align-items:center;gap:9px;padding:9px 13px;

--- a/packages/site/src/terminal.css
+++ b/packages/site/src/terminal.css
@@ -4,7 +4,7 @@
 .term{
   margin-top:40px;
   background:var(--surface);
-  border-radius:12px;overflow:hidden;
+  border-radius:8px;overflow:hidden;
 }
 .term-bar{
   display:flex;align-items:center;gap:9px;padding:9px 13px;


### PR DESCRIPTION
The terminal block's 12px radius read as too rounded; this takes it to 8px in `packages/site/src/terminal.css`, the one copy of those styles, and regenerates the two pages that render it.