### PR TITLE
Link the API reference from the landing page

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1150,6 +1150,7 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
       60 sends an hour, shared by every key on your device. Errors return JSON with a <code>code</code> and a readable
       <code>message</code>: <code>400</code> invalid parameters · <code>401</code> unknown or revoked key · <code>429</code> rate limited. <code>GET</code> works for a quick
       test; <code>POST</code> is recommended.
+      The full reference is at <a href="/docs">notifi.it/docs</a>.
     </p>
 <!-- /gen:apinote -->
   </div>

--- a/packages/apidoc/src/landing.ts
+++ b/packages/apidoc/src/landing.ts
@@ -124,6 +124,7 @@ export function landingNote(): string {
       ${SENDS_PER_HOUR} sends an hour, shared by every key on your device. Errors return JSON with a <code>code</code> and a readable
       <code>message</code>: ${codes}. <code>GET</code> works for a quick
       test; <code>POST</code> is recommended.
+      The full reference is at <a href="/docs">notifi.it/docs</a>.
     </p>`;
 }
 


### PR DESCRIPTION
The landing page's endpoint section described parameters and errors but never linked /docs — only the footer did. The line is generated from `landingNote()`, so index.html is regenerated output.