### PR TITLE
Head the README with the anaglyph bell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="apps/api/public/wordmark.svg" alt="notifi" width="260">
+  <img src="apps/api/public/anaglyph-bell.png" alt="notifi" width="140">
 </p>
 
 <p align="center"><b>Push notifications for your scripts, servers and side projects.</b></p>


### PR DESCRIPTION
Swaps the wordmark at the top of the README for `anaglyph-bell.png`, the same mark the /send examples use. The website header and every other use of the wordmark are unchanged.