### PR TITLE
Settings: cross-promote the Mac and iPhone apps

### DIFF
--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -7006,6 +7006,76 @@
         }
       }
     },
+    "settings.iosApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Get it on the App Store"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Consíguela en el App Store"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im App Store laden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger dans l'App Store"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica su App Store"
+          }
+        }
+      }
+    },
+    "settings.iosAppDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The same inbox, on your iPhone and iPad with iOS 17 or later. Each key delivers to the device that made it, so a key made on the phone lands notifications there as well as here."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La misma bandeja de entrada, en tu iPhone y iPad con iOS 17 o posterior. Cada clave entrega al dispositivo que la creó, así que una clave creada en el teléfono hace llegar allí las notificaciones además de aquí."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derselbe Posteingang, auf deinem iPhone und iPad ab iOS 17. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf dem iPhone erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La même boîte de réception, sur votre iPhone et votre iPad sous iOS 17 ou version ultérieure. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le téléphone y fait donc arriver les notifications, en plus d'ici."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La stessa casella, su iPhone e iPad con iOS 17 o successivo. Ogni chiave consegna al dispositivo che l'ha creata, quindi una chiave creata sul telefono fa arrivare lì le notifiche, oltre che qui."
+          }
+        }
+      }
+    },
     "settings.loadImages": {
       "extractionState": "manual",
       "localizations": {
@@ -7072,6 +7142,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "Recupera ogni immagine all'arrivo del messaggio, il che comunica al suo host il tuo indirizzo IP. Disattivato, le immagini si caricano solo quando vengono toccate."
+          }
+        }
+      }
+    },
+    "settings.macApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Download for Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Descargar para Mac"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für den Mac laden"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Télécharger pour Mac"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scarica per Mac"
+          }
+        }
+      }
+    },
+    "settings.macAppDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The same inbox, in your menu bar on macOS 14 or later. A direct download that keeps itself up to date. Each key delivers to the device that made it, so a key made on the Mac lands notifications there as well as here."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La misma bandeja de entrada, en la barra de menús con macOS 14 o posterior. Una descarga directa que se mantiene actualizada. Cada clave entrega al dispositivo que la creó, así que una clave creada en el Mac hace llegar allí las notificaciones además de aquí."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Derselbe Posteingang, in deiner Menüleiste ab macOS 14. Ein Direkt-Download, der sich selbst aktuell hält. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf dem Mac erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La même boîte de réception, dans votre barre des menus sous macOS 14 ou version ultérieure. Un téléchargement direct qui se met à jour tout seul. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le Mac y fait donc arriver les notifications, en plus d'ici."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La stessa casella, nella barra dei menu con macOS 14 o successivo. Un download diretto che si mantiene aggiornato. Ogni chiave consegna al dispositivo che l'ha creata, quindi una chiave creata sul Mac fa arrivare lì le notifiche, oltre che qui."
           }
         }
       }
@@ -7562,6 +7702,76 @@
           "stringUnit": {
             "state": "translated",
             "value": "Applicazione"
+          }
+        }
+      }
+    },
+    "settings.sectionIOSApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi for iPhone"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi para iPhone"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi für das iPhone"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi pour iPhone"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi per iPhone"
+          }
+        }
+      }
+    },
+    "settings.sectionMacApp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi for Mac"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi para Mac"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi für den Mac"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi pour Mac"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "notifi per Mac"
           }
         }
       }

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -198,6 +198,12 @@ enum Copy {
         static var strictSendFailed: String { NSLocalizedString("settings.strictSendFailed", comment: "") }
         static var testTitle: String { NSLocalizedString("settings.testTitle", comment: "") }
         static var testBody: String { NSLocalizedString("settings.testBody", comment: "") }
+        static var sectionMacApp: String { NSLocalizedString("settings.sectionMacApp", comment: "") }
+        static var macApp: String { NSLocalizedString("settings.macApp", comment: "") }
+        static var macAppDetail: String { NSLocalizedString("settings.macAppDetail", comment: "") }
+        static var sectionIOSApp: String { NSLocalizedString("settings.sectionIOSApp", comment: "") }
+        static var iosApp: String { NSLocalizedString("settings.iosApp", comment: "") }
+        static var iosAppDetail: String { NSLocalizedString("settings.iosAppDetail", comment: "") }
         static var sectionSupport: String { NSLocalizedString("settings.sectionSupport", comment: "") }
         static var sectionApplication: String { NSLocalizedString("settings.sectionApplication", comment: "") }
         static var sectionAbout: String { NSLocalizedString("settings.sectionAbout", comment: "") }

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -85,6 +85,50 @@ struct SettingsView: View {
                     .geistGutter()
                 }
 
+                #if os(macOS)
+                SectionLabel(text: Copy.Settings.sectionIOSApp)
+                    .geistGroupGutter()
+
+                GeistGroup {
+                    Text(Copy.Settings.iosAppDetail)
+                        .geistConsequence()
+                        .padding(.top, 14)
+                        .geistGutter()
+
+                    Link(destination: URL(string: "https://apps.apple.com/app/id1563961135")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.iosApp)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                }
+                #else
+                SectionLabel(text: Copy.Settings.sectionMacApp)
+                    .geistGroupGutter()
+
+                GeistGroup {
+                    Text(Copy.Settings.macAppDetail)
+                        .geistConsequence()
+                        .padding(.top, 14)
+                        .geistGutter()
+
+                    Link(destination: URL(string: "https://notifi.it/#download")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.macApp)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                }
+                #endif
+
                 SectionLabel(text: Copy.Settings.sectionSupport)
                     .geistGroupGutter()
 

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -341,6 +341,19 @@ export const copy = {
     testTitle: 'Hello from notifi',
     testBody: 'Your first notification.',
 
+    sectionMacApp: 'notifi for Mac',
+    macApp: 'Download for Mac',
+    macAppDetail:
+      'The same inbox, in your menu bar on macOS 14 or later. A direct download that keeps ' +
+      'itself up to date. Each key delivers to the device that made it, so a key made on the ' +
+      'Mac lands notifications there as well as here.',
+
+    sectionIOSApp: 'notifi for iPhone',
+    iosApp: 'Get it on the App Store',
+    iosAppDetail:
+      'The same inbox, on your iPhone and iPad with iOS 17 or later. Each key delivers to the ' +
+      'device that made it, so a key made on the phone lands notifications there as well as here.',
+
     sectionSupport: 'Support',
     sectionApplication: 'Application',
     sectionAbout: 'About',

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -315,6 +315,20 @@ export const de: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Deine erste Benachrichtigung.',
 
+  'settings.sectionMacApp': 'notifi für den Mac',
+  'settings.macApp': 'Für den Mac laden',
+  'settings.macAppDetail':
+    'Derselbe Posteingang, in deiner Menüleiste ab macOS 14. Ein Direkt-Download, der sich ' +
+    'selbst aktuell hält. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf ' +
+    'dem Mac erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher.',
+
+  'settings.sectionIOSApp': 'notifi für das iPhone',
+  'settings.iosApp': 'Im App Store laden',
+  'settings.iosAppDetail':
+    'Derselbe Posteingang, auf deinem iPhone und iPad ab iOS 17. Jeder Schlüssel stellt an das ' +
+    'Gerät zu, das ihn erstellt hat: Ein auf dem iPhone erstellter Schlüssel bringt ' +
+    'Benachrichtigungen also dorthin und nicht nur hierher.',
+
   'settings.sectionSupport': 'Support',
   'settings.sectionApplication': 'Anwendung',
   'settings.sectionAbout': 'Über',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -268,6 +268,20 @@ export const es: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Tu primera notificación.',
 
+  'settings.sectionMacApp': 'notifi para Mac',
+  'settings.macApp': 'Descargar para Mac',
+  'settings.macAppDetail':
+    'La misma bandeja de entrada, en la barra de menús con macOS 14 o posterior. Una descarga ' +
+    'directa que se mantiene actualizada. Cada clave entrega al dispositivo que la creó, así que ' +
+    'una clave creada en el Mac hace llegar allí las notificaciones además de aquí.',
+
+  'settings.sectionIOSApp': 'notifi para iPhone',
+  'settings.iosApp': 'Consíguela en el App Store',
+  'settings.iosAppDetail':
+    'La misma bandeja de entrada, en tu iPhone y iPad con iOS 17 o posterior. Cada clave entrega ' +
+    'al dispositivo que la creó, así que una clave creada en el teléfono hace llegar allí las ' +
+    'notificaciones además de aquí.',
+
   'settings.sectionSupport': 'Ayuda',
   'settings.sectionApplication': 'Aplicación',
   'settings.sectionAbout': 'Acerca de',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -271,6 +271,21 @@ export const fr: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Votre première notification.',
 
+  'settings.sectionMacApp': 'notifi pour Mac',
+  'settings.macApp': 'Télécharger pour Mac',
+  'settings.macAppDetail':
+    "La même boîte de réception, dans votre barre des menus sous macOS 14 ou version " +
+    "ultérieure. Un téléchargement direct qui se met à jour tout seul. Chaque clé livre à " +
+    "l'appareil qui l'a créée : une clé créée sur le Mac y fait donc arriver les notifications, " +
+    "en plus d'ici.",
+
+  'settings.sectionIOSApp': 'notifi pour iPhone',
+  'settings.iosApp': "Télécharger dans l'App Store",
+  'settings.iosAppDetail':
+    "La même boîte de réception, sur votre iPhone et votre iPad sous iOS 17 ou version " +
+    "ultérieure. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le téléphone y " +
+    "fait donc arriver les notifications, en plus d'ici.",
+
   'settings.sectionSupport': 'Assistance',
   'settings.sectionApplication': 'Application',
   'settings.sectionAbout': 'À propos',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -268,6 +268,20 @@ export const it: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'La tua prima notifica.',
 
+  'settings.sectionMacApp': 'notifi per Mac',
+  'settings.macApp': 'Scarica per Mac',
+  'settings.macAppDetail':
+    'La stessa casella, nella barra dei menu con macOS 14 o successivo. Un download diretto che ' +
+    'si mantiene aggiornato. Ogni chiave consegna al dispositivo che l\'ha creata, quindi una ' +
+    'chiave creata sul Mac fa arrivare lì le notifiche, oltre che qui.',
+
+  'settings.sectionIOSApp': 'notifi per iPhone',
+  'settings.iosApp': 'Scarica su App Store',
+  'settings.iosAppDetail':
+    'La stessa casella, su iPhone e iPad con iOS 17 o successivo. Ogni chiave consegna al ' +
+    'dispositivo che l\'ha creata, quindi una chiave creata sul telefono fa arrivare lì le ' +
+    'notifiche, oltre che qui.',
+
   'settings.sectionSupport': 'Assistenza',
   'settings.sectionApplication': 'Applicazione',
   'settings.sectionAbout': 'Informazioni',


### PR DESCRIPTION
Each build now carries a Settings section for the platform it is *not* running on, between Appearance and Support.

- **iOS** → "notifi for Mac", with a `Download for Mac` row linking to `https://notifi.it/#download`. Not `/download/mac`: that redirects straight to the DMG, which is useless on a phone.
- **macOS** → "notifi for iPhone", with a `Get it on the App Store` row linking to the listing. The Mac build already links to `apps.apple.com` for the feedback row, so that URL shape is not new here.

The detail line under each carries the part a download button does not say: a key delivers only to the device that created it, so the second app is what lets one script reach both. That is the same framing the landing page and the FAQ already use.

Copy is in `packages/copy/src/strings.ts` with hand-written es/de/fr/it; `make gen-copy` regenerated `Localizable.xcstrings` and `Copy.swift`.

### Verification

`make typecheck`, `make lint` and `make check-copy` pass.

**Not exercised:** `xcodebuild` is unavailable in the container this was written in, so neither scheme was compiled and no screenshots were taken. The repo asks a UI change to attach screenshots — this one needs a `make shots` run for the iOS `settings.png` plus a hand capture of the Mac popover, and CI's builds are the first real check that the Swift compiles.

---
_Generated by [Claude Code](https://claude.ai/code/session_014oB7tgA88xwtMjLVpyMJRg)_