### PR TITLE
Settings: regroup the sections and drop the store upsell copy

### DIFF
--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -7012,7 +7012,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Get it on the App Store"
+            "value": "Download notifi for iOS"
           }
         },
         "es": {
@@ -7037,41 +7037,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Scarica su App Store"
-          }
-        }
-      }
-    },
-    "settings.iosAppDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The same inbox, on your iPhone and iPad with iOS 17 or later. Each key delivers to the device that made it, so a key made on the phone lands notifications there as well as here."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La misma bandeja de entrada, en tu iPhone y iPad con iOS 17 o posterior. Cada clave entrega al dispositivo que la creó, así que una clave creada en el teléfono hace llegar allí las notificaciones además de aquí."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Derselbe Posteingang, auf deinem iPhone und iPad ab iOS 17. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf dem iPhone erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La même boîte de réception, sur votre iPhone et votre iPad sous iOS 17 ou version ultérieure. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le téléphone y fait donc arriver les notifications, en plus d'ici."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La stessa casella, su iPhone e iPad con iOS 17 o successivo. Ogni chiave consegna al dispositivo che l'ha creata, quindi una chiave creata sul telefono fa arrivare lì le notifiche, oltre che qui."
           }
         }
       }
@@ -7152,7 +7117,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Download for Mac"
+            "value": "Download notifi for Mac"
           }
         },
         "es": {
@@ -7177,41 +7142,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Scarica per Mac"
-          }
-        }
-      }
-    },
-    "settings.macAppDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The same inbox, in your menu bar on macOS 14 or later. A direct download that keeps itself up to date. Each key delivers to the device that made it, so a key made on the Mac lands notifications there as well as here."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La misma bandeja de entrada, en la barra de menús con macOS 14 o posterior. Una descarga directa que se mantiene actualizada. Cada clave entrega al dispositivo que la creó, así que una clave creada en el Mac hace llegar allí las notificaciones además de aquí."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Derselbe Posteingang, in deiner Menüleiste ab macOS 14. Ein Direkt-Download, der sich selbst aktuell hält. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf dem Mac erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La même boîte de réception, dans votre barre des menus sous macOS 14 ou version ultérieure. Un téléchargement direct qui se met à jour tout seul. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le Mac y fait donc arriver les notifications, en plus d'ici."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "La stessa casella, nella barra dei menu con macOS 14 o successivo. Un download diretto che si mantiene aggiornato. Ogni chiave consegna al dispositivo che l'ha creata, quindi una chiave creata sul Mac fa arrivare lì le notifiche, oltre che qui."
           }
         }
       }
@@ -7636,41 +7566,6 @@
         }
       }
     },
-    "settings.sectionAppearance": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Appearance"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apariencia"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Erscheinungsbild"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Apparence"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Aspetto"
-          }
-        }
-      }
-    },
     "settings.sectionApplication": {
       "extractionState": "manual",
       "localizations": {
@@ -7702,76 +7597,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "Applicazione"
-          }
-        }
-      }
-    },
-    "settings.sectionIOSApp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi for iPhone"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi para iPhone"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi für das iPhone"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi pour iPhone"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi per iPhone"
-          }
-        }
-      }
-    },
-    "settings.sectionMacApp": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi for Mac"
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi para Mac"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi für den Mac"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi pour Mac"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "notifi per Mac"
           }
         }
       }

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -187,7 +187,6 @@ enum Copy {
         static var permissionEphemeral: String { NSLocalizedString("settings.permissionEphemeral", comment: "") }
         static var permissionNotSet: String { NSLocalizedString("settings.permissionNotSet", comment: "") }
         static var permissionUnknown: String { NSLocalizedString("settings.permissionUnknown", comment: "") }
-        static var sectionAppearance: String { NSLocalizedString("settings.sectionAppearance", comment: "") }
         static var theme: String { NSLocalizedString("settings.theme", comment: "") }
         static var themeDark: String { NSLocalizedString("settings.themeDark", comment: "") }
         static var themeLight: String { NSLocalizedString("settings.themeLight", comment: "") }
@@ -198,12 +197,8 @@ enum Copy {
         static var strictSendFailed: String { NSLocalizedString("settings.strictSendFailed", comment: "") }
         static var testTitle: String { NSLocalizedString("settings.testTitle", comment: "") }
         static var testBody: String { NSLocalizedString("settings.testBody", comment: "") }
-        static var sectionMacApp: String { NSLocalizedString("settings.sectionMacApp", comment: "") }
         static var macApp: String { NSLocalizedString("settings.macApp", comment: "") }
-        static var macAppDetail: String { NSLocalizedString("settings.macAppDetail", comment: "") }
-        static var sectionIOSApp: String { NSLocalizedString("settings.sectionIOSApp", comment: "") }
         static var iosApp: String { NSLocalizedString("settings.iosApp", comment: "") }
-        static var iosAppDetail: String { NSLocalizedString("settings.iosAppDetail", comment: "") }
         static var sectionSupport: String { NSLocalizedString("settings.sectionSupport", comment: "") }
         static var sectionApplication: String { NSLocalizedString("settings.sectionApplication", comment: "") }
         static var sectionAbout: String { NSLocalizedString("settings.sectionAbout", comment: "") }

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -72,7 +72,7 @@ struct SettingsView: View {
                 }
                 .animation(Theme.state, value: strictSendFailed)
 
-                SectionLabel(text: Copy.Settings.sectionAppearance)
+                SectionLabel(text: Copy.Settings.sectionApplication)
                     .geistGroupGutter()
 
                 GeistGroup {
@@ -83,84 +83,8 @@ struct SettingsView: View {
                         selection: $model.appearance
                     )
                     .geistGutter()
-                }
-
-                #if os(macOS)
-                SectionLabel(text: Copy.Settings.sectionIOSApp)
-                    .geistGroupGutter()
-
-                GeistGroup {
-                    Text(Copy.Settings.iosAppDetail)
-                        .geistConsequence()
-                        .padding(.top, 14)
-                        .geistGutter()
-
-                    Link(destination: URL(string: "https://apps.apple.com/app/id1563961135")!) {
-                        DisclosureRow {
-                            Text(Copy.Settings.iosApp)
-                                .font(Theme.body)
-                                .foregroundStyle(Theme.fg)
-                        }
-                        .padding(.vertical, Theme.rowPadV)
-                    }
-                    .buttonStyle(.geistRow)
-                    .geistGutter()
-                }
-                #else
-                SectionLabel(text: Copy.Settings.sectionMacApp)
-                    .geistGroupGutter()
-
-                GeistGroup {
-                    Text(Copy.Settings.macAppDetail)
-                        .geistConsequence()
-                        .padding(.top, 14)
-                        .geistGutter()
-
-                    Link(destination: URL(string: "https://notifi.it/#download")!) {
-                        DisclosureRow {
-                            Text(Copy.Settings.macApp)
-                                .font(Theme.body)
-                                .foregroundStyle(Theme.fg)
-                        }
-                        .padding(.vertical, Theme.rowPadV)
-                    }
-                    .buttonStyle(.geistRow)
-                    .geistGutter()
-                }
-                #endif
-
-                SectionLabel(text: Copy.Settings.sectionSupport)
-                    .geistGroupGutter()
-
-                GeistGroup {
-                    Link(destination: URL(string: "mailto:report@notifi.it")!) {
-                        DisclosureRow {
-                            Text(Copy.Settings.support)
-                                .font(Theme.body)
-                                .foregroundStyle(Theme.fg)
-                        }
-                        .padding(.vertical, Theme.rowPadV)
-                    }
-                    .buttonStyle(.geistRow)
-                    .geistGutter()
                     RowRule()
 
-                    Link(destination: URL(string: "https://apps.apple.com/app/id1563961135?action=write-review")!) {
-                        DisclosureRow {
-                            Text(Copy.Settings.feedback)
-                                .font(Theme.body)
-                                .foregroundStyle(Theme.fg)
-                        }
-                        .padding(.vertical, Theme.rowPadV)
-                    }
-                    .buttonStyle(.geistRow)
-                    .geistGutter()
-                }
-
-                SectionLabel(text: Copy.Settings.sectionApplication)
-                    .geistGroupGutter()
-
-                GeistGroup {
                     #if os(macOS)
                     ToggleRow(
                         title: Copy.Settings.openAtLogin,
@@ -201,6 +125,20 @@ struct SettingsView: View {
                     #endif
 
                     Button {
+                        model.openSystemNotificationSettings()
+                    } label: {
+                        DisclosureRow {
+                            Text(Copy.Settings.openSystemSettings)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                    RowRule()
+
+                    Button {
                         confirmingDeleteAll = true
                     } label: {
                         DisclosureRow {
@@ -218,15 +156,10 @@ struct SettingsView: View {
                     .geistGroupGutter()
 
                 GeistGroup {
-                    FieldRow(Copy.Settings.version, AppModel.appVersion)
-                        .geistGutter()
-                    RowRule()
-
-                    Button {
-                        model.openSystemNotificationSettings()
-                    } label: {
+                    #if os(macOS)
+                    Link(destination: URL(string: "https://apps.apple.com/app/id1563961135")!) {
                         DisclosureRow {
-                            Text(Copy.Settings.openSystemSettings)
+                            Text(Copy.Settings.iosApp)
                                 .font(Theme.body)
                                 .foregroundStyle(Theme.fg)
                         }
@@ -235,6 +168,19 @@ struct SettingsView: View {
                     .buttonStyle(.geistRow)
                     .geistGutter()
                     RowRule()
+                    #else
+                    Link(destination: URL(string: "https://notifi.it/#download")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.macApp)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                    RowRule()
+                    #endif
 
                     Link(destination: URL(string: "https://notifi.it/privacy")!) {
                         DisclosureRow {
@@ -251,6 +197,38 @@ struct SettingsView: View {
                     Link(destination: URL(string: "https://notifi.it")!) {
                         DisclosureRow {
                             Text(Copy.Settings.website)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                    RowRule()
+
+                    FieldRow(Copy.Settings.version, AppModel.appVersion)
+                        .geistGutter()
+                }
+
+                SectionLabel(text: Copy.Settings.sectionSupport)
+                    .geistGroupGutter()
+
+                GeistGroup {
+                    Link(destination: URL(string: "mailto:report@notifi.it")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.support)
+                                .font(Theme.body)
+                                .foregroundStyle(Theme.fg)
+                        }
+                        .padding(.vertical, Theme.rowPadV)
+                    }
+                    .buttonStyle(.geistRow)
+                    .geistGutter()
+                    RowRule()
+
+                    Link(destination: URL(string: "https://apps.apple.com/app/id1563961135?action=write-review")!) {
+                        DisclosureRow {
+                            Text(Copy.Settings.feedback)
                                 .font(Theme.body)
                                 .foregroundStyle(Theme.fg)
                         }

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -321,7 +321,6 @@ export const copy = {
     permissionNotSet: 'Not set',
     permissionUnknown: 'Unknown',
 
-    sectionAppearance: 'Appearance',
     theme: 'Theme',
     themeDark: 'Dark',
     themeLight: 'Light',
@@ -341,18 +340,8 @@ export const copy = {
     testTitle: 'Hello from notifi',
     testBody: 'Your first notification.',
 
-    sectionMacApp: 'notifi for Mac',
-    macApp: 'Download for Mac',
-    macAppDetail:
-      'The same inbox, in your menu bar on macOS 14 or later. A direct download that keeps ' +
-      'itself up to date. Each key delivers to the device that made it, so a key made on the ' +
-      'Mac lands notifications there as well as here.',
-
-    sectionIOSApp: 'notifi for iPhone',
-    iosApp: 'Get it on the App Store',
-    iosAppDetail:
-      'The same inbox, on your iPhone and iPad with iOS 17 or later. Each key delivers to the ' +
-      'device that made it, so a key made on the phone lands notifications there as well as here.',
+    macApp: 'Download notifi for Mac',
+    iosApp: 'Download notifi for iOS',
 
     sectionSupport: 'Support',
     sectionApplication: 'Application',

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -295,7 +295,6 @@ export const de: Translation = {
   'settings.permissionNotSet': 'Nicht festgelegt',
   'settings.permissionUnknown': 'Unbekannt',
 
-  'settings.sectionAppearance': 'Erscheinungsbild',
   'settings.theme': 'Design',
   'settings.themeDark': 'Dunkel',
   'settings.themeLight': 'Hell',
@@ -315,19 +314,9 @@ export const de: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Deine erste Benachrichtigung.',
 
-  'settings.sectionMacApp': 'notifi für den Mac',
   'settings.macApp': 'Für den Mac laden',
-  'settings.macAppDetail':
-    'Derselbe Posteingang, in deiner Menüleiste ab macOS 14. Ein Direkt-Download, der sich ' +
-    'selbst aktuell hält. Jeder Schlüssel stellt an das Gerät zu, das ihn erstellt hat: Ein auf ' +
-    'dem Mac erstellter Schlüssel bringt Benachrichtigungen also dorthin und nicht nur hierher.',
 
-  'settings.sectionIOSApp': 'notifi für das iPhone',
   'settings.iosApp': 'Im App Store laden',
-  'settings.iosAppDetail':
-    'Derselbe Posteingang, auf deinem iPhone und iPad ab iOS 17. Jeder Schlüssel stellt an das ' +
-    'Gerät zu, das ihn erstellt hat: Ein auf dem iPhone erstellter Schlüssel bringt ' +
-    'Benachrichtigungen also dorthin und nicht nur hierher.',
 
   'settings.sectionSupport': 'Support',
   'settings.sectionApplication': 'Anwendung',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -248,7 +248,6 @@ export const es: Translation = {
   'settings.permissionNotSet': 'Sin definir',
   'settings.permissionUnknown': 'Desconocido',
 
-  'settings.sectionAppearance': 'Apariencia',
   'settings.theme': 'Tema',
   'settings.themeDark': 'Oscuro',
   'settings.themeLight': 'Claro',
@@ -268,19 +267,9 @@ export const es: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Tu primera notificación.',
 
-  'settings.sectionMacApp': 'notifi para Mac',
   'settings.macApp': 'Descargar para Mac',
-  'settings.macAppDetail':
-    'La misma bandeja de entrada, en la barra de menús con macOS 14 o posterior. Una descarga ' +
-    'directa que se mantiene actualizada. Cada clave entrega al dispositivo que la creó, así que ' +
-    'una clave creada en el Mac hace llegar allí las notificaciones además de aquí.',
 
-  'settings.sectionIOSApp': 'notifi para iPhone',
   'settings.iosApp': 'Consíguela en el App Store',
-  'settings.iosAppDetail':
-    'La misma bandeja de entrada, en tu iPhone y iPad con iOS 17 o posterior. Cada clave entrega ' +
-    'al dispositivo que la creó, así que una clave creada en el teléfono hace llegar allí las ' +
-    'notificaciones además de aquí.',
 
   'settings.sectionSupport': 'Ayuda',
   'settings.sectionApplication': 'Aplicación',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -251,7 +251,6 @@ export const fr: Translation = {
   'settings.permissionNotSet': 'Non défini',
   'settings.permissionUnknown': 'Inconnue',
 
-  'settings.sectionAppearance': 'Apparence',
   'settings.theme': 'Thème',
   'settings.themeDark': 'Sombre',
   'settings.themeLight': 'Clair',
@@ -271,20 +270,9 @@ export const fr: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'Votre première notification.',
 
-  'settings.sectionMacApp': 'notifi pour Mac',
   'settings.macApp': 'Télécharger pour Mac',
-  'settings.macAppDetail':
-    "La même boîte de réception, dans votre barre des menus sous macOS 14 ou version " +
-    "ultérieure. Un téléchargement direct qui se met à jour tout seul. Chaque clé livre à " +
-    "l'appareil qui l'a créée : une clé créée sur le Mac y fait donc arriver les notifications, " +
-    "en plus d'ici.",
 
-  'settings.sectionIOSApp': 'notifi pour iPhone',
   'settings.iosApp': "Télécharger dans l'App Store",
-  'settings.iosAppDetail':
-    "La même boîte de réception, sur votre iPhone et votre iPad sous iOS 17 ou version " +
-    "ultérieure. Chaque clé livre à l'appareil qui l'a créée : une clé créée sur le téléphone y " +
-    "fait donc arriver les notifications, en plus d'ici.",
 
   'settings.sectionSupport': 'Assistance',
   'settings.sectionApplication': 'Application',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -248,7 +248,6 @@ export const it: Translation = {
   'settings.permissionNotSet': 'Non impostata',
   'settings.permissionUnknown': 'Sconosciuta',
 
-  'settings.sectionAppearance': 'Aspetto',
   'settings.theme': 'Tema',
   'settings.themeDark': 'Scuro',
   'settings.themeLight': 'Chiaro',
@@ -268,19 +267,9 @@ export const it: Translation = {
   'settings.testTitle': 'Hello from notifi',
   'settings.testBody': 'La tua prima notifica.',
 
-  'settings.sectionMacApp': 'notifi per Mac',
   'settings.macApp': 'Scarica per Mac',
-  'settings.macAppDetail':
-    'La stessa casella, nella barra dei menu con macOS 14 o successivo. Un download diretto che ' +
-    'si mantiene aggiornato. Ogni chiave consegna al dispositivo che l\'ha creata, quindi una ' +
-    'chiave creata sul Mac fa arrivare lì le notifiche, oltre che qui.',
 
-  'settings.sectionIOSApp': 'notifi per iPhone',
   'settings.iosApp': 'Scarica su App Store',
-  'settings.iosAppDetail':
-    'La stessa casella, su iPhone e iPad con iOS 17 o successivo. Ogni chiave consegna al ' +
-    'dispositivo che l\'ha creata, quindi una chiave creata sul telefono fa arrivare lì le ' +
-    'notifiche, oltre che qui.',
 
   'settings.sectionSupport': 'Assistenza',
   'settings.sectionApplication': 'Applicazione',


### PR DESCRIPTION
Appearance held a single control and the cross-promotion section spent a paragraph selling the other platform before offering its link, so Theme and Open system settings move into Application, the upsell collapses to one row in About, and Support moves to the end. The link now reads "Download notifi for Mac" (and "Download notifi for iOS" on the Mac build), and five copy keys left unused by the removal go with it.

Screenshots follow in a comment — the CLI cannot upload images.

Not verified: the macOS popover is compile-checked only, not screenshotted. The four translations of `macApp`/`iosApp` still carry the old wording, since retranslating them here would be the machine translation the repo rules out.