### PR TITLE
Hold the offline banner steady and flatten the empty state

### DIFF
--- a/apps/app/Shared/API/SocketClient.swift
+++ b/apps/app/Shared/API/SocketClient.swift
@@ -58,6 +58,7 @@ final class SocketClient {
     private static let silenceLimit: TimeInterval = 100
 
     private func connectAndListen() async {
+        var sawFrame = false
         do {
             let request = try api.socketRequest()
             let socket = URLSession.shared.webSocketTask(with: request)
@@ -65,8 +66,7 @@ final class SocketClient {
             socket.resume()
 
             await onWake(nil)
-            attempt = 0
-            enter(.connected)
+            try? await socket.send(.string("ping"))
 
             var lastInbound = Date()
             let heartbeat = Task { [weak self] in
@@ -86,6 +86,11 @@ final class SocketClient {
             while !Task.isCancelled {
                 let frame = try await socket.receive()
                 lastInbound = Date()
+                if !sawFrame {
+                    sawFrame = true
+                    attempt = 0
+                    enter(.connected)
+                }
                 if case .string("pong") = frame { continue }
                 var unpushed: Int?
                 if case .string(let text) = frame,
@@ -100,7 +105,7 @@ final class SocketClient {
         }
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
-        if !Task.isCancelled { enter(.failed) }
+        if !Task.isCancelled, !sawFrame { enter(.failed) }
     }
 
     private func backOff() async {

--- a/apps/app/Shared/Resources/Localizable.xcstrings
+++ b/apps/app/Shared/Resources/Localizable.xcstrings
@@ -2591,41 +2591,6 @@
         }
       }
     },
-    "empty.sentDetail": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "It arrives here and on your lock screen. Make more keys under Keys to keep sources apart."
-          }
-        },
-        "es": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Llega aquí y a tu pantalla de bloqueo. Crea más claves en Claves para mantener las fuentes separadas."
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Sie kommt hier und auf deinem Sperrbildschirm an. Erstelle unter Schlüssel weitere, um Quellen zu trennen."
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Elle arrive ici et sur votre écran verrouillé. Créez d’autres clés dans Clés pour distinguer les sources."
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Arriva qui e sulla schermata di blocco. Crea altre chiavi in Chiavi per tenere separate le fonti."
-          }
-        }
-      }
-    },
     "empty.stepAllow": {
       "extractionState": "manual",
       "localizations": {

--- a/apps/app/Shared/Support/Copy.swift
+++ b/apps/app/Shared/Support/Copy.swift
@@ -228,7 +228,6 @@ enum Copy {
         static var sendTest: String { NSLocalizedString("empty.sendTest", comment: "") }
         static var sending: String { NSLocalizedString("empty.sending", comment: "") }
         static var sent: String { NSLocalizedString("empty.sent", comment: "") }
-        static var sentDetail: String { NSLocalizedString("empty.sentDetail", comment: "") }
         static var sendFailed: String { NSLocalizedString("empty.sendFailed", comment: "") }
         static var makingKey: String { NSLocalizedString("empty.makingKey", comment: "") }
         static var makeKeyFailed: String { NSLocalizedString("empty.makeKeyFailed", comment: "") }

--- a/apps/app/Shared/Support/Theme.swift
+++ b/apps/app/Shared/Support/Theme.swift
@@ -85,6 +85,7 @@ enum Theme {
     #endif
 
     static let headerBarHeight: CGFloat = 30
+    static let headerSubtitleHeight: CGFloat = 22
     static let headerActionSpacing: CGFloat = 8
 
     static let headerBarGap: CGFloat = 20

--- a/apps/app/Shared/Support/Theme.swift
+++ b/apps/app/Shared/Support/Theme.swift
@@ -105,8 +105,11 @@ enum Theme {
 
     #if os(macOS)
     static let contentTop: CGFloat = firstBlockTop
+    static let listContentTop: CGFloat = contentTop
     #else
     static let contentTop: CGFloat = topFade + firstBlockTop
+    static let listIntrinsicTopInset: CGFloat = 3
+    static let listContentTop: CGFloat = contentTop - listIntrinsicTopInset
     #endif
 
     static let press = Animation.easeOut(duration: 0.12)
@@ -138,10 +141,6 @@ enum Theme {
 
 extension View {
     func geistGutter() -> some View { padding(.horizontal, Theme.gutter) }
-
-    func geistGroupGutter() -> some View {
-        padding(.horizontal, Theme.groupInset + Theme.gutter)
-    }
 
     func geistBannerTransition() -> some View {
         transition(Theme.reduceMotion

--- a/apps/app/Shared/Views/Components/FeedHeader.swift
+++ b/apps/app/Shared/Views/Components/FeedHeader.swift
@@ -22,18 +22,18 @@ struct FeedHeader<Trailing: View, Accessory: View>: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
                     .frame(height: Theme.headerBarHeight, alignment: .leading)
-                if let subtitle {
-                    subtitle
-                        .font(Theme.meta)
-                        .foregroundColor(Theme.muted)
-                        .lineLimit(1)
-                } else {
-                    Text(verbatim: " ")
-                        .font(Theme.meta)
-                        .hidden()
-                        .accessibilityHidden(true)
-                        .overlay(alignment: .topLeading) { accessory().fixedSize() }
+                ZStack(alignment: .leading) {
+                    Color.clear.frame(width: 0, height: Theme.headerSubtitleHeight)
+                    if let subtitle {
+                        subtitle
+                            .font(Theme.meta)
+                            .foregroundColor(Theme.muted)
+                            .lineLimit(1)
+                    } else {
+                        accessory().fixedSize()
+                    }
                 }
+                .frame(height: Theme.headerSubtitleHeight, alignment: .leading)
             }
             Spacer(minLength: 8)
             HStack(spacing: Theme.headerActionSpacing) {

--- a/apps/app/Shared/Views/Components/FeedHeader.swift
+++ b/apps/app/Shared/Views/Components/FeedHeader.swift
@@ -2,7 +2,7 @@ import OSLog
 import SwiftData
 import SwiftUI
 
-struct FeedHeader<Trailing: View>: View {
+struct FeedHeader<Trailing: View, Accessory: View>: View {
     @Environment(AppModel.self) private var model
     @Environment(\.modelContext) private var context
     @Query(sort: \Message.createdAt, order: .reverse) private var messages: [Message]
@@ -10,6 +10,7 @@ struct FeedHeader<Trailing: View>: View {
     var subtitle: Text? = nil
     @Binding var filterKeyID: Int?
     @ViewBuilder var trailing: () -> Trailing
+    @ViewBuilder var accessory: () -> Accessory
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -31,6 +32,7 @@ struct FeedHeader<Trailing: View>: View {
                         .font(Theme.meta)
                         .hidden()
                         .accessibilityHidden(true)
+                        .overlay(alignment: .topLeading) { accessory().fixedSize() }
                 }
             }
             Spacer(minLength: 8)
@@ -110,8 +112,14 @@ struct FeedHeader<Trailing: View>: View {
     }
 }
 
-extension FeedHeader where Trailing == EmptyView {
+extension FeedHeader where Trailing == EmptyView, Accessory == EmptyView {
     init(subtitle: Text? = nil, filterKeyID: Binding<Int?>) {
-        self.init(subtitle: subtitle, filterKeyID: filterKeyID) { EmptyView() }
+        self.init(subtitle: subtitle, filterKeyID: filterKeyID, trailing: { EmptyView() }, accessory: { EmptyView() })
+    }
+}
+
+extension FeedHeader where Accessory == EmptyView {
+    init(subtitle: Text? = nil, filterKeyID: Binding<Int?>, @ViewBuilder trailing: @escaping () -> Trailing) {
+        self.init(subtitle: subtitle, filterKeyID: filterKeyID, trailing: trailing, accessory: { EmptyView() })
     }
 }

--- a/apps/app/Shared/Views/Components/GeistComponents.swift
+++ b/apps/app/Shared/Views/Components/GeistComponents.swift
@@ -70,6 +70,8 @@ struct Chip: View {
     var color: Color = Theme.muted
     var border: Color = Theme.chip
     var trailingGlyph: String?
+    var trailingSymbol: String?
+    var trailingSymbolColor: Color = Theme.dim
 
     var body: some View {
         HStack(spacing: 5) {
@@ -78,6 +80,11 @@ struct Chip: View {
                 .truncationMode(.middle)
             if let trailingGlyph {
                 Text(trailingGlyph)
+            }
+            if let trailingSymbol {
+                Image(systemName: trailingSymbol)
+                    .imageScale(.small)
+                    .foregroundStyle(trailingSymbolColor)
             }
         }
         .font(Theme.label)
@@ -492,16 +499,15 @@ struct GeistHeader<Trailing: View>: View {
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)
                     .frame(height: Theme.headerBarHeight, alignment: .leading)
-                if let subtitle {
-                    Text(subtitle)
-                        .font(Theme.meta)
-                        .foregroundStyle(Theme.muted)
-                } else {
-                    Text(verbatim: " ")
-                        .font(Theme.meta)
-                        .hidden()
-                        .accessibilityHidden(true)
+                ZStack(alignment: .leading) {
+                    Color.clear.frame(width: 0, height: Theme.headerSubtitleHeight)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(Theme.meta)
+                            .foregroundStyle(Theme.muted)
+                    }
                 }
+                .frame(height: Theme.headerSubtitleHeight, alignment: .leading)
             }
             Spacer(minLength: 8)
             HStack(spacing: Theme.headerActionSpacing) {

--- a/apps/app/Shared/Views/Components/MessageFeed.swift
+++ b/apps/app/Shared/Views/Components/MessageFeed.swift
@@ -30,7 +30,7 @@ struct MessageFeed<Empty: View>: View {
                 BandHeader(title: DayBand.title(for: band.day, now: now),
                            count: band.messages.count,
                            isFirst: band.id == banded.first?.id)
-                    .padding(.horizontal, 18)
+                    .geistGutter()
                     .plainRow()
 
                 ForEach(Array(band.messages.enumerated()),
@@ -60,7 +60,7 @@ struct MessageFeed<Empty: View>: View {
         #if os(macOS)
         .contentMargins(.bottom, Theme.bottomPlate, for: .scrollContent)
         #endif
-        .contentMargins(.top, Theme.contentTop, for: .scrollContent)
+        .contentMargins(.top, Theme.listContentTop, for: .scrollContent)
         .geistTopFade()
         .background(Color.clear)
         .scrollDismissesKeyboard(.immediately)

--- a/apps/app/Shared/Views/EmptyStateView.swift
+++ b/apps/app/Shared/Views/EmptyStateView.swift
@@ -9,7 +9,6 @@ struct EmptyStateView: View {
     @State private var sendError: String?
     @State private var key: String?
     @State private var keyFailed = false
-    @State private var openStep = 1
 
     private static let sampleTitle = Copy.Empty.sampleTitle
     private static let sampleMessage = Copy.Empty.sampleMessage
@@ -83,105 +82,78 @@ struct EmptyStateView: View {
                 .padding(.top, 26)
                 .padding(.bottom, 22)
 
-            VStack(alignment: .leading, spacing: 22) {
-                OnboardingStep(
-                    number: 1,
-                    title: Copy.Empty.stepAllow,
-                    done: notificationsAllowed,
-                    open: openStep == 1,
-                    toggle: { openStep = openStep == 1 ? 0 : 1 }
-                ) {
-                    if notificationsAllowed {
-                        Text(Copy.Empty.notificationsOn)
-                            .font(Theme.metaSmall)
-                            .foregroundStyle(Theme.muted)
-                    } else if model.notificationStatus == .denied {
-                        OutlineButton(title: Copy.Settings.openSystemSettings, fill: true) {
+            VStack(alignment: .leading, spacing: 10) {
+                if !notificationsAllowed {
+                    OutlineButton(title: Copy.Empty.enableNotifications, fill: true) {
+                        if model.notificationStatus == .denied {
                             model.openSystemNotificationSettings()
-                        }
-                    } else {
-                        OutlineButton(title: Copy.Empty.enableNotifications, fill: true) {
+                        } else {
                             Task {
                                 await model.requestNotificationPermission()
                             }
                         }
                     }
+
+                    Hairline()
+                        .padding(.vertical, 12)
                 }
 
-                OnboardingStep(
-                    number: 2,
-                    title: Copy.Empty.stepSend,
-                    open: openStep == 2,
-                    toggle: { openStep = openStep == 2 ? 0 : 2 }
-                ) {
-                    if let key {
-                        let command = command(key: key)
+                if let key {
+                    let command = command(key: key)
 
-                        Text(self.command(key: Self.displayKey(key)))
-                            .font(Theme.metaSmall)
-                            .foregroundStyle(Theme.fg)
-                            .fixedSize(horizontal: false, vertical: true)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(12)
-                            .background(RoundedRectangle(cornerRadius: Theme.radius).fill(Theme.surface))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: Theme.radius)
-                                    .stroke(Theme.line, lineWidth: 1)
-                            )
+                    Text(self.command(key: Self.displayKey(key)))
+                        .font(Theme.metaSmall)
+                        .foregroundStyle(Theme.fg)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(12)
+                        .background(RoundedRectangle(cornerRadius: Theme.radius).fill(Theme.surface))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.radius)
+                                .stroke(Theme.line, lineWidth: 1)
+                        )
 
-                        HStack(spacing: 10) {
-                            OutlineButton(title: copied ? Copy.Common.copied : Copy.Common.copy, fill: true) {
-                                Clipboard.copySensitive(command)
-                                copied = true
-                            }
-
-                            OutlineButton(title: sending ? Copy.Empty.sending : Copy.Empty.sendTest, fill: true) {
-                                send()
-                            }
-                            .disabled(sending)
+                    HStack(spacing: 10) {
+                        OutlineButton(title: copied ? Copy.Common.copied : Copy.Common.copy, fill: true) {
+                            Clipboard.copySensitive(command)
+                            copied = true
                         }
 
-                        if let sendError {
-                            InlineError(message: sendError)
-                        } else if sent {
-                            AnnouncedText(
-                                message: Copy.Empty.sent,
-                                color: Theme.muted
-                            )
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        } else {
-                            Text(Copy.Empty.sentDetail)
-                                .font(Theme.metaSmall)
-                                .foregroundStyle(Theme.muted)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+                        OutlineButton(title: sending ? Copy.Empty.sending : Copy.Empty.sendTest, fill: true) {
+                            send()
                         }
-                    } else if keyFailed {
-                        InlineError(message: Copy.Empty.makeKeyFailed)
-
-                        OutlineButton(title: Copy.Common.tryAgain, fill: true) {
-                            Task { await loadKey() }
-                        }
-                    } else {
-                        Text(Copy.Empty.makingKey)
-                            .font(Theme.metaSmall)
-                            .foregroundStyle(Theme.muted)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        .disabled(sending)
                     }
+
+                    if let sendError {
+                        InlineError(message: sendError)
+                    } else if sent {
+                        AnnouncedText(
+                            message: Copy.Empty.sent,
+                            color: Theme.muted
+                        )
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                } else if keyFailed {
+                    InlineError(message: Copy.Empty.makeKeyFailed)
+
+                    OutlineButton(title: Copy.Common.tryAgain, fill: true) {
+                        Task { await loadKey() }
+                    }
+                } else {
+                    Text(Copy.Empty.makingKey)
+                        .font(Theme.metaSmall)
+                        .foregroundStyle(Theme.muted)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
+            .animation(Theme.reveal, value: notificationsAllowed)
         }
         .frame(maxWidth: 360)
         .geistGutter()
         .padding(.vertical, 40)
         .frame(maxWidth: .infinity)
         .task { await loadKey() }
-        .onAppear {
-            openStep = notificationsAllowed ? 2 : 1
-        }
-        .onChange(of: notificationsAllowed) { _, allowed in
-            if allowed, openStep == 1 { openStep = 2 }
-        }
     }
 }
 
@@ -279,97 +251,5 @@ private struct SeededGenerator: RandomNumberGenerator {
         state ^= state >> 7
         state ^= state << 17
         return state
-    }
-}
-
-private let onboardingSoftEdge: CGFloat = 22
-
-private struct OnboardingStep<Content: View>: View {
-    var number: Int
-    var title: String
-    var done: Bool = false
-    var open: Bool
-    var toggle: () -> Void
-    @ViewBuilder var content: Content
-
-    @State private var contentHeight: CGFloat = 0
-    @State private var revealed: CGFloat = 0
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button(action: toggle) {
-            HStack(spacing: 8) {
-                Group {
-                    if done {
-                        Image(systemName: "checkmark")
-                            .font(.system(size: 10, weight: .bold))
-                            .foregroundStyle(Theme.bg)
-                            .symbolEffect(.bounce, value: done)
-                            .transition(.opacity)
-                    } else {
-                        Text("\(number)")
-                            .font(.inco(.footnote, weight: .bold))
-                            .foregroundStyle(Theme.fg)
-                            .transition(.opacity)
-                    }
-                }
-                .frame(width: 20, height: 20)
-                .background(Circle().fill(done ? Theme.fg : Theme.chip))
-
-                Text(title)
-                    .font(.inco(.footnote, weight: .semibold))
-                    .foregroundStyle(done ? Theme.dim : Theme.fg)
-
-                Spacer(minLength: 8)
-
-                Image(systemName: "chevron.down")
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Theme.muted)
-                    .rotationEffect(.degrees(open ? 0 : -90))
-            }
-            .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(Copy.Empty.stepLabel("\(number)", title) + (done ? Copy.Empty.stepDone : ""))
-            .accessibilityHint(open ? Copy.Common.collapse : Copy.Common.expand)
-
-            VStack(alignment: .leading, spacing: 10) {
-                content
-            }
-            .padding(.top, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .fixedSize(horizontal: false, vertical: true)
-            .background {
-                GeometryReader { proxy in
-                    Color.clear
-                        .onChange(of: proxy.size.height, initial: true) { _, height in
-                            contentHeight = height
-                        }
-                }
-            }
-            .geometryGroup()
-            .frame(height: contentHeight * revealed, alignment: .top)
-            .mask(alignment: .top) {
-                VStack(spacing: 0) {
-                    Rectangle()
-                    LinearGradient(
-                        colors: [Color.black, Color.black.opacity(0)],
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                    .frame(height: onboardingSoftEdge * (1 - revealed))
-                }
-            }
-            .clipped()
-            .accessibilityHidden(!open)
-            .onChange(of: open, initial: true) { _, isOpen in
-                withAnimation(Theme.reveal) { revealed = isOpen ? 1 : 0 }
-            }
-        }
-        .geometryGroup()
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .animation(Theme.state, value: done)
-        .animation(Theme.reveal, value: open)
     }
 }

--- a/apps/app/Shared/Views/InboxView.swift
+++ b/apps/app/Shared/Views/InboxView.swift
@@ -149,15 +149,14 @@ struct InboxView: View {
                 #endif
             } accessory: {
                 if !messages.isEmpty, let activeKeyName {
-                    HStack(spacing: 8) {
+                    Button { filterKeyID = nil } label: {
                         Chip(text: activeKeyName, color: Theme.fg,
-                             border: Theme.muted.opacity(0.5))
-                        Button(Copy.Common.clear) { filterKeyID = nil }
-                            .font(Theme.label)
-                            .foregroundStyle(Theme.dim)
-                            .buttonStyle(.geist)
-                            .geistHitArea(expandedBy: 16)
+                             border: Theme.muted.opacity(0.5),
+                             trailingSymbol: "xmark")
                     }
+                    .buttonStyle(.geist)
+                    .geistHitArea(expandedBy: 12)
+                    .accessibilityLabel(Copy.Common.clear)
                 }
             }
             .padding(.bottom, hasHeaderControls ? 14 : 0)

--- a/apps/app/Shared/Views/InboxView.swift
+++ b/apps/app/Shared/Views/InboxView.swift
@@ -135,9 +135,9 @@ struct InboxView: View {
 
     private var hasHeaderControls: Bool {
         #if os(macOS)
-        !messages.isEmpty && (showingSearch || activeKeyName != nil)
+        !messages.isEmpty && showingSearch
         #else
-        !messages.isEmpty && activeKeyName != nil
+        false
         #endif
     }
 
@@ -147,17 +147,8 @@ struct InboxView: View {
                 #if os(macOS)
                 if !messages.isEmpty { searchToggle }
                 #endif
-            }
-            .padding(.bottom, hasHeaderControls ? 14 : 0)
-
-            if !messages.isEmpty {
-                #if os(macOS)
-                if showingSearch {
-                    SearchField(text: $searchText, focused: $searchFocused)
-                }
-                #endif
-
-                if let activeKeyName {
+            } accessory: {
+                if !messages.isEmpty, let activeKeyName {
                     HStack(spacing: 8) {
                         Chip(text: activeKeyName, color: Theme.fg,
                              border: Theme.muted.opacity(0.5))
@@ -166,11 +157,16 @@ struct InboxView: View {
                             .foregroundStyle(Theme.dim)
                             .buttonStyle(.geist)
                             .geistHitArea(expandedBy: 16)
-                        Spacer(minLength: 0)
                     }
-                    .padding(.top, 10)
                 }
             }
+            .padding(.bottom, hasHeaderControls ? 14 : 0)
+
+            #if os(macOS)
+            if !messages.isEmpty, showingSearch {
+                SearchField(text: $searchText, focused: $searchFocused)
+            }
+            #endif
         }
     }
 

--- a/apps/app/Shared/Views/SettingsView.swift
+++ b/apps/app/Shared/Views/SettingsView.swift
@@ -17,7 +17,7 @@ struct SettingsView: View {
         } content: {
             VStack(alignment: .leading, spacing: 0) {
                 SectionLabel(text: Copy.Settings.sectionPermissions, isFirst: true)
-                    .geistGroupGutter()
+                    .geistGutter()
 
                 GeistGroup {
                     if model.notificationStatus != .authorized {
@@ -73,7 +73,7 @@ struct SettingsView: View {
                 .animation(Theme.state, value: strictSendFailed)
 
                 SectionLabel(text: Copy.Settings.sectionApplication)
-                    .geistGroupGutter()
+                    .geistGutter()
 
                 GeistGroup {
                     SegmentedRow(
@@ -153,7 +153,7 @@ struct SettingsView: View {
                 }
 
                 SectionLabel(text: Copy.Settings.sectionAbout)
-                    .geistGroupGutter()
+                    .geistGutter()
 
                 GeistGroup {
                     #if os(macOS)
@@ -211,7 +211,7 @@ struct SettingsView: View {
                 }
 
                 SectionLabel(text: Copy.Settings.sectionSupport)
-                    .geistGroupGutter()
+                    .geistGutter()
 
                 GeistGroup {
                     Link(destination: URL(string: "mailto:report@notifi.it")!) {

--- a/packages/copy/src/strings.ts
+++ b/packages/copy/src/strings.ts
@@ -376,8 +376,6 @@ export const copy = {
     sendTest: 'Send a test',
     sending: 'Sending…',
     sent: 'Sent. It arrives here and on your lock screen in a moment.',
-    sentDetail:
-      'It arrives here and on your lock screen. Make more keys under Keys to keep sources apart.',
     sendFailed: "Couldn't send. Check your connection and try again.",
 
     makingKey: 'Making your key…',

--- a/packages/copy/src/translations/de.ts
+++ b/packages/copy/src/translations/de.ts
@@ -349,8 +349,6 @@ export const de: Translation = {
   'empty.sendTest': 'Test senden',
   'empty.sending': 'Wird gesendet…',
   'empty.sent': 'Gesendet. Sie kommt gleich hier und auf deinem Sperrbildschirm an.',
-  'empty.sentDetail':
-    'Sie kommt hier und auf deinem Sperrbildschirm an. Erstelle unter Schlüssel weitere, um Quellen zu trennen.',
   'empty.sendFailed': 'Senden fehlgeschlagen. Verbindung prüfen und erneut versuchen.',
 
   'empty.makingKey': 'Dein Schlüssel wird erstellt…',

--- a/packages/copy/src/translations/es.ts
+++ b/packages/copy/src/translations/es.ts
@@ -302,8 +302,6 @@ export const es: Translation = {
   'empty.sendTest': 'Enviar una prueba',
   'empty.sending': 'Enviando…',
   'empty.sent': 'Enviado. Llegará aquí y a tu pantalla de bloqueo en un momento.',
-  'empty.sentDetail':
-    'Llega aquí y a tu pantalla de bloqueo. Crea más claves en Claves para mantener las fuentes separadas.',
   'empty.sendFailed': 'No se pudo enviar. Comprueba tu conexión e inténtalo de nuevo.',
 
   'empty.makingKey': 'Creando tu clave…',

--- a/packages/copy/src/translations/fr.ts
+++ b/packages/copy/src/translations/fr.ts
@@ -306,9 +306,6 @@ export const fr: Translation = {
   'empty.sendTest': 'Envoyer un test',
   'empty.sending': 'Envoi…',
   'empty.sent': 'Envoyée. Elle arrive ici et sur votre écran verrouillé dans un instant.',
-  'empty.sentDetail':
-    'Elle arrive ici et sur votre écran verrouillé. Créez d’autres clés dans Clés pour ' +
-    'distinguer les sources.',
   'empty.sendFailed': "Échec de l'envoi. Vérifiez votre connexion et réessayez.",
 
   'empty.makingKey': 'Création de votre clé…',

--- a/packages/copy/src/translations/it.ts
+++ b/packages/copy/src/translations/it.ts
@@ -302,8 +302,6 @@ export const it: Translation = {
   'empty.sendTest': 'Invia una prova',
   'empty.sending': 'Invio…',
   'empty.sent': 'Inviata. Arriverà qui e sulla schermata di blocco tra un momento.',
-  'empty.sentDetail':
-    'Arriva qui e sulla schermata di blocco. Crea altre chiavi in Chiavi per tenere separate le fonti.',
   'empty.sendFailed': 'Impossibile inviare. Controlla la connessione e riprova.',
 
   'empty.makingKey': 'Creazione della chiave…',


### PR DESCRIPTION
The socket entered `.connected` as soon as URLSession created the task, before the server had answered, so each reconnect attempt hid the offline banner for a moment and it flickered against an unreachable origin; it now only reports `.connected` once a frame actually comes back, and a drop of a live connection gets one silent retry before the banner returns. The inbox empty state loses its accordion — the permission button and the curl card with Copy / Send a test are always visible, the button reads "Enable notifications" in the denied case too (where it opens system settings, because iOS will not re-show the prompt), and the `empty.sentDetail` line is gone from the catalogue and its four translations. Both headers now reserve `Theme.headerSubtitleHeight` for the subtitle line, held open by a zero-width spacer since a frame around `EmptyView` collapses; the key filter chip lives in that line, so filtering no longer moves the feed. Clearing the filter folds into the chip itself: the pill carries a dim xmark and a tap anywhere on it clears.

Both `xcodebuild` schemes, `make typecheck` and `make lint` pass. There are no automated tests. Verified on the Simulator, phone and iPad: with the filter on and off the section rule and first row land on identical pixel rows, the three tab titles share a baseline at both widths, and the banner holds steady across reconnect attempts against an unreachable port. **The reconnect-to-a-live-server path has not been exercised** and wants a check against `make dev` before merge.