### PR TITLE
Daily App Store and send-volume summary

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -1,0 +1,41 @@
+name: daily-summary
+
+# Sales reports need a Sales-access App Store Connect key: the key the reviews
+# workflow uses is Admin, and a key's access cannot be widened after it is
+# created. Downloads count first installs only (product types 1 and 1F) —
+# updates (7/7F) dwarf them on a release day and are not growth.
+on:
+  schedule:
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: daily-summary
+  cancel-in-progress: false
+
+jobs:
+  summarise:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - run: pip install requests pyjwt cryptography
+      - name: Send the daily summary
+        working-directory: apps/api
+        env:
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_SALES_KEY_ID }}
+          ASC_SALES_KEY_P8: ${{ secrets.ASC_SALES_KEY_P8 }}
+          ASC_VENDOR_NUMBER: ${{ secrets.ASC_VENDOR_NUMBER }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          NOTIFI_SEND_KEY: ${{ secrets.NOTIFI_SEND_KEY }}
+        run: |
+          ASC_PRIVATE_KEY="$(echo "$ASC_SALES_KEY_P8" | base64 --decode)" \
+            python scripts/daily_summary.py

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -79,6 +79,10 @@ def query_production_d1(sql):
     return body["result"][0]["results"][0]
 
 
+def senders(count):
+    return f"{count} device" + ("" if count == 1 else "s")
+
+
 def week_on_week(now, before, percent_floor=10):
     if before >= percent_floor:
         return f"{'+' if now >= before else ''}{round((now - before) / before * 100)}%"
@@ -93,38 +97,71 @@ def compose_notification():
         for n in range(1, 15)
     ]
 
-    yesterday, countries = reports[0]
-    this_week = sum(n for n, _ in reports[:7])
-    prior_week = sum(n for n, _ in reports[7:])
+    downloads_yesterday, countries = reports[0]
+    downloads_week = sum(n for n, _ in reports[:7])
+    downloads_prior = sum(n for n, _ in reports[7:])
 
-    stats = query_production_d1(
-        "SELECT (SELECT COUNT(*) FROM devices) AS devices,"
-        " (SELECT COUNT(*) FROM devices WHERE created_at >= unixepoch()-604800) AS devices_wk,"
-        " (SELECT COUNT(*) FROM app_reviews) AS reviews"
+    day = query_production_d1(
+        "SELECT COUNT(*) AS sends, COUNT(DISTINCT device_id) AS senders"
+        " FROM messages WHERE created_at >= unixepoch()-86400"
     )
-    sends = query_production_d1(
-        "SELECT SUM(CASE WHEN created_at >= unixepoch()-604800 THEN 1 ELSE 0 END) AS wk,"
-        " SUM(CASE WHEN created_at >= unixepoch()-1209600 AND created_at < unixepoch()-604800 THEN 1 ELSE 0 END) AS prior,"
-        " MIN(created_at) AS oldest FROM messages"
+    week = query_production_d1(
+        "SELECT COUNT(*) AS sends, COUNT(DISTINCT device_id) AS senders"
+        " FROM messages WHERE created_at >= unixepoch()-604800"
+    )
+    prior = query_production_d1(
+        "SELECT COUNT(*) AS sends FROM messages"
+        " WHERE created_at >= unixepoch()-1209600 AND created_at < unixepoch()-604800"
+    )
+    history = query_production_d1("SELECT MIN(created_at) AS oldest FROM messages")
+    devices = query_production_d1(
+        "SELECT COUNT(*) AS total,"
+        " SUM(CASE WHEN created_at >= unixepoch()-86400 THEN 1 ELSE 0 END) AS day,"
+        " SUM(CASE WHEN created_at >= unixepoch()-604800 THEN 1 ELSE 0 END) AS week"
+        " FROM devices"
+    )
+    reviews = query_production_d1(
+        "SELECT COUNT(*) AS total,"
+        " SUM(CASE WHEN fetched_at >= unixepoch()-604800 THEN 1 ELSE 0 END) AS week"
+        " FROM app_reviews"
     )
 
-    comparable = sends["oldest"] is not None and sends["oldest"] <= int(time.time()) - 2 * WEEK
-    plural = "" if yesterday == 1 else "s"
+    comparable = (
+        history["oldest"] is not None and history["oldest"] <= int(time.time()) - 2 * WEEK
+    )
+    sends_week = (
+        f"- Sends **{week['sends']}** from {senders(week['senders'])}"
+        f" ({week_on_week(week['sends'], prior['sends'])} vs prior 7d)"
+        if comparable
+        else f"- Sends **{week['sends']}** from {senders(week['senders'])}"
+        " · _no prior week to compare yet_"
+    )
+    plural = "" if downloads_yesterday == 1 else "s"
 
     lines = [
-        f"**{yesterday}** download{plural} yesterday · **{this_week}** this week "
-        f"({week_on_week(this_week, prior_week)} vs prior 7d).",
+        f"**{downloads_yesterday}** download{plural} and "
+        f"**{day['sends']}** send{'' if day['sends'] == 1 else 's'} yesterday.",
         "",
-        f"- Sends **{sends['wk']}** this week ({week_on_week(sends['wk'], sends['prior'])} vs prior 7d)"
-        if comparable
-        else f"- Sends **{sends['wk']}** this week · _no prior week to compare yet_",
-        f"- Devices **{stats['devices']}** · +{stats['devices_wk']} this week",
-        f"- Reviews **{stats['reviews']}**",
+        "**Yesterday**",
+        f"- Sends **{day['sends']}** from {senders(day['senders'])}",
+        f"- Downloads **{downloads_yesterday}**",
+        f"- Devices **+{devices['day']}**",
+        "",
+        "**This week**",
+        sends_week,
+        f"- Downloads **{downloads_week}**"
+        f" ({week_on_week(downloads_week, downloads_prior)} vs prior 7d)",
+        f"- Devices **+{devices['week']}** · {devices['total']} total",
+        f"- Reviews **+{reviews['week']}** · {reviews['total']} total",
     ]
     if countries:
         lines.append("- From " + " · ".join(f"{c} {n}" for c, n in countries.most_common(4)))
 
-    return f"notifi · {yesterday} download{plural} yesterday", "\n".join(lines)
+    title = (
+        f"notifi · {downloads_yesterday} download{plural}, "
+        f"{day['sends']} send{'' if day['sends'] == 1 else 's'}"
+    )
+    return title, "\n".join(lines)
 
 
 def send_daily_summary():

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -1,0 +1,146 @@
+import csv
+import gzip
+import io
+import os
+import sys
+import time
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+
+import jwt
+import requests
+
+ASC_SALES = "https://api.appstoreconnect.apple.com/v1/salesReports"
+NOTIFI_SEND = "https://notifi.it/send"
+D1_QUERY = (
+    "https://api.cloudflare.com/client/v4/accounts/{account}/d1/database/{database}/query"
+)
+FIRST_INSTALL = {"1", "1F"}
+WEEK = 604800
+SESSION = requests.Session()
+SESSION.headers["User-Agent"] = "notifi-daily-summary"
+
+
+def app_store_connect_token():
+    key = os.environ.get("ASC_PRIVATE_KEY")
+    if key is None:
+        key = open(os.environ["ASC_KEY_PATH"]).read()
+    now = int(time.time())
+    return jwt.encode(
+        {"iss": os.environ["ASC_ISSUER_ID"], "iat": now, "exp": now + 600, "aud": "appstoreconnect-v1"},
+        key,
+        algorithm="ES256",
+        headers={"kid": os.environ["ASC_KEY_ID"]},
+    )
+
+
+def first_installs_on(token, day):
+    res = SESSION.get(
+        ASC_SALES,
+        headers={"Authorization": f"Bearer {token}", "Accept": "application/a-gzip"},
+        params={
+            "filter[frequency]": "DAILY",
+            "filter[reportType]": "SALES",
+            "filter[reportSubType]": "SUMMARY",
+            "filter[vendorNumber]": os.environ["ASC_VENDOR_NUMBER"],
+            "filter[reportDate]": day,
+        },
+        timeout=30,
+    )
+    if res.status_code == 404:
+        return 0, Counter()
+    res.raise_for_status()
+
+    tsv = gzip.decompress(res.content).decode()
+    total, countries = 0, Counter()
+    for row in csv.DictReader(io.StringIO(tsv), delimiter="\t"):
+        if row["Product Type Identifier"] not in FIRST_INSTALL:
+            continue
+        units = int(row["Units"])
+        total += units
+        countries[row["Country Code"]] += units
+    return total, countries
+
+
+def query_production_d1(sql):
+    res = SESSION.post(
+        D1_QUERY.format(
+            account=os.environ["CLOUDFLARE_ACCOUNT_ID"],
+            database=os.environ["D1_DATABASE_ID"],
+        ),
+        headers={"Authorization": f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}"},
+        json={"sql": sql},
+        timeout=30,
+    )
+    res.raise_for_status()
+    body = res.json()
+    if not body["success"]:
+        raise SystemExit(f"D1 query failed: {body['errors']}")
+    return body["result"][0]["results"][0]
+
+
+def week_on_week(now, before, percent_floor=10):
+    if before >= percent_floor:
+        return f"{'+' if now >= before else ''}{round((now - before) / before * 100)}%"
+    return f"{'+' if now >= before else ''}{now - before}"
+
+
+def compose_notification():
+    token = app_store_connect_token()
+    today = datetime.now(timezone.utc)
+    reports = [
+        first_installs_on(token, (today - timedelta(days=n)).strftime("%Y-%m-%d"))
+        for n in range(1, 15)
+    ]
+
+    yesterday, countries = reports[0]
+    this_week = sum(n for n, _ in reports[:7])
+    prior_week = sum(n for n, _ in reports[7:])
+
+    stats = query_production_d1(
+        "SELECT (SELECT COUNT(*) FROM devices) AS devices,"
+        " (SELECT COUNT(*) FROM devices WHERE created_at >= unixepoch()-604800) AS devices_wk,"
+        " (SELECT COUNT(*) FROM app_reviews) AS reviews"
+    )
+    sends = query_production_d1(
+        "SELECT SUM(CASE WHEN created_at >= unixepoch()-604800 THEN 1 ELSE 0 END) AS wk,"
+        " SUM(CASE WHEN created_at >= unixepoch()-1209600 AND created_at < unixepoch()-604800 THEN 1 ELSE 0 END) AS prior,"
+        " MIN(created_at) AS oldest FROM messages"
+    )
+
+    comparable = sends["oldest"] is not None and sends["oldest"] <= int(time.time()) - 2 * WEEK
+    plural = "" if yesterday == 1 else "s"
+
+    lines = [
+        f"**{yesterday}** download{plural} yesterday · **{this_week}** this week "
+        f"({week_on_week(this_week, prior_week)} vs prior 7d).",
+        "",
+        f"- Sends **{sends['wk']}** this week ({week_on_week(sends['wk'], sends['prior'])} vs prior 7d)"
+        if comparable
+        else f"- Sends **{sends['wk']}** this week · _no prior week to compare yet_",
+        f"- Devices **{stats['devices']}** · +{stats['devices_wk']} this week",
+        f"- Reviews **{stats['reviews']}**",
+    ]
+    if countries:
+        lines.append("- From " + " · ".join(f"{c} {n}" for c, n in countries.most_common(4)))
+
+    return f"notifi · {yesterday} download{plural} yesterday", "\n".join(lines)
+
+
+def send_daily_summary():
+    title, body = compose_notification()
+    if "--dry-run" in sys.argv:
+        print(f"--- title ---\n{title}\n--- body ---\n{body}")
+        return
+    res = SESSION.post(
+        NOTIFI_SEND,
+        data={"key": os.environ["NOTIFI_SEND_KEY"], "title": title, "message": body},
+        timeout=30,
+    )
+    print(f"send: {res.status_code}")
+    if not res.ok:
+        raise SystemExit(res.text[:200])
+
+
+if __name__ == "__main__":
+    send_daily_summary()


### PR DESCRIPTION
A scheduled job that pushes one notification a morning: yesterday's first-time downloads from the App Store Connect sales report, plus sends, devices and reviews from production D1 over its REST API. Percentages appear only once a prior week is large enough to carry them, since at current volumes one download to three reads as +200%.

Needs five new repository secrets before it can run — the existing `ASC_API_KEY_P8` is an Admin key and App Store Connect refuses sales reports to it, so this uses a separate Sales-access key:

| Secret | Value |
|---|---|
| `ASC_SALES_KEY_P8` | base64 of the Sales key's `.p8` (stored in 1Password) |
| `ASC_SALES_KEY_ID` | `72QNU94596` |
| `ASC_VENDOR_NUMBER` | `86158697` |
| `CLOUDFLARE_ACCOUNT_ID` | `88ac6c7ebcb389c95a0a171916d0784a` |
| `D1_DATABASE_ID` | `e6e8c82f-779f-4e27-9621-97426939ea9b` |

Verified by running against live App Store Connect and production D1; three test notifications were delivered (202).

Draft because two numbers still need explaining: 18 Aug carries a 224-message burst that will distort the first week-on-week sends figure, and devices grew by 14 against 6 App Store downloads.