### PR TITLE
Site traffic, active keys, honest review count

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -35,6 +35,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
+          CF_ZONE_ID: fc704965663c004c389f89eece06176a
           NOTIFI_SEND_KEY: ${{ secrets.NOTIFI_SEND_KEY }}
         run: |
           ASC_PRIVATE_KEY="$(echo "$ASC_SALES_KEY_P8" | base64 --decode)" \

--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -36,6 +36,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           D1_DATABASE_ID: ${{ secrets.D1_DATABASE_ID }}
           CF_ZONE_ID: fc704965663c004c389f89eece06176a
+          CF_RUM_SITE_TAG: 85beb8ede6934dffa16eef0029e2d780
           NOTIFI_SEND_KEY: ${{ secrets.NOTIFI_SEND_KEY }}
         run: |
           ASC_PRIVATE_KEY="$(echo "$ASC_SALES_KEY_P8" | base64 --decode)" \

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -188,14 +188,14 @@ def compose_notification():
         f"- Sends **{day['sends']}** from {senders(day['senders'])}",
         f"- Downloads **{downloads_yesterday}**",
         f"- Devices **+{devices['day']}**",
-        f"- Site **{site_yday_u}** visitors · {site_yday_v} views",
+        f"- Site **{site_yday_u}** visitors · {site_yday_v} page loads incl. bots",
         "",
         "**This week**",
         sends_week,
         f"- Downloads **{downloads_week}**"
         f" ({week_on_week(downloads_week, downloads_prior)} vs prior 7d)",
         f"- Site **{site_wk_u}** visitors ({week_on_week(site_wk_u, site_prior_u)} vs prior 7d)"
-        f" · {site_wk_v} views",
+        f" · {site_wk_v} page loads incl. bots",
         f"- Devices **+{devices['week']}** · {devices['total']} total",
         f"- Active keys **{active_keys['n']}**",
         f"- Reviews **+{reviews['week']}** · {reviews['total']} total",

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -15,6 +15,7 @@ NOTIFI_SEND = "https://notifi.it/send"
 D1_QUERY = (
     "https://api.cloudflare.com/client/v4/accounts/{account}/d1/database/{database}/query"
 )
+CF_GRAPHQL = "https://api.cloudflare.com/client/v4/graphql"
 FIRST_INSTALL = {"1", "1F"}
 WEEK = 604800
 SESSION = requests.Session()
@@ -83,6 +84,42 @@ def senders(count):
     return f"{count} device" + ("" if count == 1 else "s")
 
 
+def site_traffic():
+    query = (
+        '{ viewer { zones(filter: {zoneTag: "%s"})'
+        " { httpRequests1dGroups(limit: 15, filter: {date_gt: \"%s\"}, orderBy: [date_ASC])"
+        " { dimensions { date } sum { pageViews } uniq { uniques } } } } }"
+    ) % (
+        os.environ["CF_ZONE_ID"],
+        (datetime.now(timezone.utc) - timedelta(days=15)).strftime("%Y-%m-%d"),
+    )
+    res = SESSION.post(
+        CF_GRAPHQL,
+        headers={"Authorization": f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}"},
+        json={"query": query},
+        timeout=30,
+    )
+    res.raise_for_status()
+    body = res.json()
+    if body.get("errors"):
+        raise SystemExit(f"zone analytics failed: {body['errors'][0]['message']}")
+    days = {
+        g["dimensions"]["date"]: (g["uniq"]["uniques"], g["sum"]["pageViews"])
+        for g in body["data"]["viewer"]["zones"][0]["httpRequests1dGroups"]
+    }
+
+    def window(start, end):
+        u = v = 0
+        for n in range(start, end):
+            day = (datetime.now(timezone.utc) - timedelta(days=n)).strftime("%Y-%m-%d")
+            du, dv = days.get(day, (0, 0))
+            u += du
+            v += dv
+        return u, v
+
+    return window(1, 2), window(1, 8), window(8, 15)
+
+
 def week_on_week(now, before, percent_floor=10):
     if before >= percent_floor:
         return f"{'+' if now >= before else ''}{round((now - before) / before * 100)}%"
@@ -122,9 +159,14 @@ def compose_notification():
     )
     reviews = query_production_d1(
         "SELECT COUNT(*) AS total,"
-        " SUM(CASE WHEN fetched_at >= unixepoch()-604800 THEN 1 ELSE 0 END) AS week"
+        " SUM(CASE WHEN substr(updated_at,1,10) >= date('now','-7 days') THEN 1 ELSE 0 END) AS week"
         " FROM app_reviews"
     )
+    active_keys = query_production_d1(
+        "SELECT COUNT(*) AS n FROM keys"
+        " WHERE revoked_at IS NULL AND last_used_at >= unixepoch()-604800"
+    )
+    (site_yday_u, site_yday_v), (site_wk_u, site_wk_v), (site_prior_u, _) = site_traffic()
 
     comparable = (
         history["oldest"] is not None and history["oldest"] <= int(time.time()) - 2 * WEEK
@@ -146,12 +188,16 @@ def compose_notification():
         f"- Sends **{day['sends']}** from {senders(day['senders'])}",
         f"- Downloads **{downloads_yesterday}**",
         f"- Devices **+{devices['day']}**",
+        f"- Site **{site_yday_u}** visitors · {site_yday_v} views",
         "",
         "**This week**",
         sends_week,
         f"- Downloads **{downloads_week}**"
         f" ({week_on_week(downloads_week, downloads_prior)} vs prior 7d)",
+        f"- Site **{site_wk_u}** visitors ({week_on_week(site_wk_u, site_prior_u)} vs prior 7d)"
+        f" · {site_wk_v} views",
         f"- Devices **+{devices['week']}** · {devices['total']} total",
+        f"- Active keys **{active_keys['n']}**",
         f"- Reviews **+{reviews['week']}** · {reviews['total']} total",
     ]
     if countries:

--- a/apps/api/scripts/daily_summary.py
+++ b/apps/api/scripts/daily_summary.py
@@ -120,6 +120,44 @@ def site_traffic():
     return window(1, 2), window(1, 8), window(8, 15)
 
 
+def measured_humans():
+    def clause(alias, start, end):
+        return (
+            '%s: rumPageloadEventsAdaptiveGroups(limit: 1, filter:'
+            ' {siteTag: "%s", date_geq: "%s", date_leq: "%s"})'
+            " { sum { visits } }"
+        ) % (
+            alias,
+            os.environ["CF_RUM_SITE_TAG"],
+            (datetime.now(timezone.utc) - timedelta(days=start)).strftime("%Y-%m-%d"),
+            (datetime.now(timezone.utc) - timedelta(days=end)).strftime("%Y-%m-%d"),
+        )
+
+    query = '{ viewer { accounts(filter: {accountTag: "%s"}) { %s %s %s } } }' % (
+        os.environ["CLOUDFLARE_ACCOUNT_ID"],
+        clause("yesterday", 1, 1),
+        clause("week", 7, 1),
+        clause("prior", 14, 8),
+    )
+    res = SESSION.post(
+        CF_GRAPHQL,
+        headers={"Authorization": f"Bearer {os.environ['CLOUDFLARE_API_TOKEN']}"},
+        json={"query": query},
+        timeout=30,
+    )
+    res.raise_for_status()
+    body = res.json()
+    if body.get("errors"):
+        raise SystemExit(f"web analytics failed: {body['errors'][0]['message']}")
+    account = body["data"]["viewer"]["accounts"][0]
+
+    def visits(alias):
+        groups = account[alias]
+        return groups[0]["sum"]["visits"] if groups else 0
+
+    return visits("yesterday"), visits("week"), visits("prior")
+
+
 def week_on_week(now, before, percent_floor=10):
     if before >= percent_floor:
         return f"{'+' if now >= before else ''}{round((now - before) / before * 100)}%"
@@ -167,6 +205,7 @@ def compose_notification():
         " WHERE revoked_at IS NULL AND last_used_at >= unixepoch()-604800"
     )
     (site_yday_u, site_yday_v), (site_wk_u, site_wk_v), (site_prior_u, _) = site_traffic()
+    humans_yday, humans_wk, humans_prior = measured_humans()
 
     comparable = (
         history["oldest"] is not None and history["oldest"] <= int(time.time()) - 2 * WEEK
@@ -188,14 +227,14 @@ def compose_notification():
         f"- Sends **{day['sends']}** from {senders(day['senders'])}",
         f"- Downloads **{downloads_yesterday}**",
         f"- Devices **+{devices['day']}**",
-        f"- Site **{site_yday_u}** visitors · {site_yday_v} page loads incl. bots",
+        f"- Site **{humans_yday}** measured humans · {site_yday_u} IPs · {site_yday_v} loads",
         "",
         "**This week**",
         sends_week,
         f"- Downloads **{downloads_week}**"
         f" ({week_on_week(downloads_week, downloads_prior)} vs prior 7d)",
-        f"- Site **{site_wk_u}** visitors ({week_on_week(site_wk_u, site_prior_u)} vs prior 7d)"
-        f" · {site_wk_v} page loads incl. bots",
+        f"- Site **{humans_wk}** measured humans ({week_on_week(humans_wk, humans_prior)} vs prior 7d)"
+        f" · {site_wk_u} IPs · {site_wk_v} loads",
         f"- Devices **+{devices['week']}** · {devices['total']} total",
         f"- Active keys **{active_keys['n']}**",
         f"- Reviews **+{reviews['week']}** · {reviews['total']} total",


### PR DESCRIPTION
Adds to the daily summary: unique visitors and page views for notifi.it (Cloudflare zone analytics via GraphQL, week-on-week), and keys used in the last 7 days. Visitors lead the site line because views diverged 3x from flat uniques on 20-22 Aug — agent traffic on the markdown pages, not people.

Fixes the review count: it compared `fetched_at`, which the nightly reviews refresh resets on every row, so all 8 reviews read as new each day; it now uses the review's own `updated_at`, giving +0 this week (newest review is 4 Aug).

Needs no new secrets — the CI token gained `Analytics:Read` on the notifi.it zone today; the zone id is in the workflow in the clear.

Verified with a dry run against live zone analytics and production D1.