### PR TITLE
Match the Markdown heading to the section on the page

### DIFF
--- a/apps/api/public/index.md
+++ b/apps/api/public/index.md
@@ -25,7 +25,7 @@ own send keys, for marketing, and for anything where a missed notification
 causes harm: a key delivers only to the device that made it, and delivery is
 best-effort.
 
-## How it compares
+## Why not just use ...
 
 - Quicker to set up than an **SMTP relay**
 - Your important notifications in one place, without cluttering your **inbox**


### PR DESCRIPTION
index.md is hand-written rather than generated, so renaming the section's eyebrow to "Why not just use ..." in #289 left its Markdown sibling still headed "How it compares". The two served versions of the landing page named the same section differently — to readers in HTML and to agents in Markdown.