### PR TITLE
Split the Homebrew line and name the inbox as email

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1565,7 +1565,7 @@ spec:
       <div class="use-col">
         <ul>
           <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-mail"/></svg>Quicker to set up than an <b>SMTP relay</b></li>
-          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-split"/></svg>Your important notifications in one place, without cluttering your <b>inbox</b></li>
+          <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-split"/></svg>Your important notifications in one place, without cluttering your <b>email inbox</b></li>
           <li><svg class="ico" aria-hidden="true" focusable="false"><use href="#i-air"/></svg>Lighter than running <b>Slack</b></li>
         </ul>
       </div>
@@ -1661,7 +1661,8 @@ spec:
         <span class="lbl"><b>Download&nbsp;the&nbsp;Mac&nbsp;app&nbsp;(.dmg)</b><span>Apple silicon or T2 · macOS 14+</span></span>
       </a>
       <p class="meta">Both apps are free, with no account to create.</p>
-      <p class="meta">The Mac build updates itself. <a href="https://brew.sh" class="src">Homebrew</a> works too:</p>
+      <p class="meta">The Mac build updates itself.</p>
+      <p class="meta"><a href="https://brew.sh" class="src">Homebrew</a> works too:</p>
     </div>
 
     <div class="term term-brew">

--- a/apps/api/public/index.md
+++ b/apps/api/public/index.md
@@ -28,7 +28,7 @@ best-effort.
 ## Why not just use ...
 
 - Quicker to set up than an **SMTP relay**
-- Your important notifications in one place, without cluttering your **inbox**
+- Your important notifications in one place, without cluttering your **email inbox**
 - Lighter than running **Slack**
 - No bot to register, unlike **Telegram**
 - Custom formatting, unlike **SMS**


### PR DESCRIPTION
The download section put "The Mac build updates itself" and the Homebrew pointer on one line; they are separate facts and now sit on separate lines above the terminal.

"Without cluttering your inbox" also read ambiguously, since the app has an inbox of its own — the comparison is against email, so it now says so.