### PR TITLE
Fit the film head beside the phone

### DIFF
--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -506,9 +506,9 @@ section{padding:clamp(48px,7vw,86px) 0}
 .gf-gif .gf-l1{--fs:2.3;color:var(--red)}
 .gf-head .gf-l2{--fs:2.0;font-weight:400;color:var(--muted)}
 @media(min-width:761px){
-.gf-head{top:5.4%}
-.gf-head .gf-l1{--fs:3.1}
-.gf-head .gf-l2{--fs:2.2}
+.gf-head{top:5.4%;width:55%}
+.gf-head .gf-l1{--fs:2.35}
+.gf-head .gf-l2{--fs:2.1}
 }
 .gf-term{position:absolute;left:4.17%;top:24.5%;width:38.43%;height:55%;container-type:inline-size;background:var(--surface);border-radius:1.1cqw;overflow:hidden}
 .gf-term .gf-bar{position:relative;display:flex;align-items:center;gap:1.301cqw;padding:2.342cqw 3.123cqw}

--- a/sketches/gif/gen.py
+++ b/sketches/gif/gen.py
@@ -229,9 +229,9 @@ body{{background:#161618;min-height:100vh;display:grid;place-items:center;paddin
 .gif .l1{{--fs:2.3;color:var(--red)}}
 .head .l2{{--fs:2.0;font-weight:400;color:var(--muted)}}
 @media(min-width:761px){{
-.head{{top:5.4%}}
-.head .l1{{--fs:3.1}}
-.head .l2{{--fs:2.2}}
+.head{{top:5.4%;width:55%}}
+.head .l1{{--fs:2.35}}
+.head .l2{{--fs:2.1}}
 }}
 .term{{position:absolute;{TERM};container-type:inline-size;background:var(--surface);border-radius:1.1cqw;overflow:hidden}}
 .term .bar{{position:relative;display:flex;align-items:center;gap:1.301cqw;padding:2.342cqw 3.123cqw}}


### PR DESCRIPTION
The h2-scale scene head from #297 ran the first scene's long headline under the iPhone frame. The head now caps its width at 55% and steps down to 2.35cqw, which clears the device frames on all three scenes; the change lives in sketches/gif/gen.py and the film is regenerated from it.