### PR TITLE
Drop the Built by line from the footer

### DIFF
--- a/apps/api/public/404.html
+++ b/apps/api/public/404.html
@@ -394,7 +394,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 

--- a/apps/api/public/docs.html
+++ b/apps/api/public/docs.html
@@ -1136,7 +1136,6 @@ spec:
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 

--- a/apps/api/public/faq.html
+++ b/apps/api/public/faq.html
@@ -354,7 +354,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 

--- a/apps/api/public/index.html
+++ b/apps/api/public/index.html
@@ -1711,7 +1711,6 @@ spec:
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 <!-- /gen:footer -->

--- a/apps/api/public/privacy.html
+++ b/apps/api/public/privacy.html
@@ -366,7 +366,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 

--- a/apps/api/public/terms.html
+++ b/apps/api/public/terms.html
@@ -314,7 +314,6 @@ footer{border-top:1px solid var(--line);padding:40px 0 56px}
     <a href="https://x.com/notifiit" rel="me">X</a>
     <a href="https://instagram.com/notifidotit" rel="me">Instagram</a>
     <a href="https://facebook.com/notifidotit" rel="me">Facebook</a>
-    <span class="meta">Built by Maximilian Mitchell</span>
   </div>
 </footer>
 

--- a/packages/site/src/chrome.ts
+++ b/packages/site/src/chrome.ts
@@ -1,4 +1,4 @@
-import { AUTHOR, EMAIL, GITHUB, ORIGIN, OG_IMAGE, OG_IMAGE_ALT, SOCIAL, THEME_COLOR } from './constants.js';
+import { EMAIL, GITHUB, ORIGIN, OG_IMAGE, OG_IMAGE_ALT, SOCIAL, THEME_COLOR } from './constants.js';
 
 export interface Link {
   href: string;
@@ -127,7 +127,6 @@ export function footer(meta: Meta): string {
        only what is not up there — and never a link to the page you are on. -->
   <div class="wrap foot">
 ${links.map((link) => `    ${tag(link)}`).join('\n')}
-    <span class="meta">Built by ${AUTHOR}</span>
   </div>
 </footer>`;
 }


### PR DESCRIPTION
The footer loses its "Built by" credit on all eight pages; the schema.org founder field keeps the name for structured data. The line was the footer's only non-link content, so nothing else moves.